### PR TITLE
Fix dropped scanline, while maintaining cycle-perfectness

### DIFF
--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -648,8 +648,7 @@ void avr8::update_hardware(int cycles)
 
 			if (TCNT1 > (0xFFFF - cycles)){
 
-				 //TIFR1|=TOV1; //overflow interrupt
-				tempTIFR1|=TOV1; //overflow interrupt
+				 TIFR1|=TOV1; //overflow interrupt
 
 			}
 
@@ -684,8 +683,7 @@ void avr8::update_hardware(int cycles)
 
 			if (TCNT1 > (0xFFFF - cycles)){
 				if (TIMSK1 & TOIE1){
-					 //TIFR1|=TOV1; //overflow interrupt
-					tempTIFR1|=TOV1; //overflow interrupt
+					TIFR1|=TOV1; //overflow interrupt
 				}
 			}
 			TCNT1 += cycles;
@@ -830,7 +828,7 @@ void avr8::update_hardware(int cycles)
 
 
 	TCCR1B=newTCCR1B; //Timer increments starts after executing the instruction that sets TCCR1B
-	TIFR1=tempTIFR1;
+	TIFR1|=tempTIFR1;
 }
 
 u8 avr8::exec()


### PR DESCRIPTION
@uze6666 According to the datasheet, TOV1 needs to be written immediately, and we need to OR any new bit flags we set that cycle, otherwise we'll blow away any immediate change that also happened to TIFR1 that cycle (such as the clearing of the interrupt flag, which would cause a duplicate interrupt and a double-increment of the scanline count, causing us to miss the first scanline).

For more information, see: http://uzebox.org/forums/viewtopic.php?f=9&t=2274&p=16125#p16125