### PR TITLE
Remove SDL_RENDERER_PRESENTVSYNC flag, so the emulator is sync'd with…

### DIFF
--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -1652,7 +1652,7 @@ bool avr8::init_gui()
 		fprintf(stderr, "CreateWindow failed: %s\n", SDL_GetError());
 		return false;
 	}
-	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
 	if (!renderer){
 		SDL_DestroyWindow(window);
 		fprintf(stderr, "CreateRenderer failed: %s\n", SDL_GetError());


### PR DESCRIPTION
… the sound again

Jubatian correctly pointed out that this could interfere with the sound generation.