### PR TITLE
Uzem140 hacks

### DIFF
--- a/tools/uzem/Makefile
+++ b/tools/uzem/Makefile
@@ -203,6 +203,7 @@ $(TARGET_NAME): $(TARGET_OBJS) $(SDL_DLL)
 
 $(TARGET_OBJ_DIR)/%.o: %.cpp
 	$(CC) -c $< -o $@ $(TARGET_CPPFLAGS) $(DEPFLAGS) $(TARGET_D_DEFINES)
+	$(CC) -c -S $< -o $@.asm $(TARGET_CPPFLAGS) $(DEPFLAGS) $(TARGET_D_DEFINES)
 
 # This rule used only for Windows
 $(SDL_DLL): $(SDL_DLL_FROM)

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -263,17 +263,29 @@ void avr8::spi_calculateClock(){
     SPI_DEBUG("SPI divider set to : %d (%d cycles per byte)\n",spiClockDivider,spiCycleWait);
 }
 
-void avr8::write_io(u8 addr,u8 value)
+
+inline void avr8::write_io(u8 addr,u8 value)
+{
+	// Pixel output ideally should inline, it is performed about 2 - 3
+	// million times per second in a Uzebox game.
+	if (addr == ports::PORTC)
+	{
+		pixel = palette[value & DDRC];
+	}
+	else
+	{
+		write_io_x(addr, value);
+	}
+}
+
+// Should not be called directly, use write_io instead (pixel output!)
+void avr8::write_io_x(u8 addr,u8 value)
 {
 	u8 changed;
 	u8 went_low;
 
 	switch (addr)
 	{
-	case (ports::PORTC):
-		pixel = palette[value & DDRC];
-		break;
-
 	case (ports::OCR2A):
 		if (enableSound && TCCR2B)
 		{

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -132,13 +132,35 @@ static const char* joySettingsFilename = "joystick-settings";
 #define BIT(x,b)	(((x)>>(b))&1)
 #define C			BIT(SREG,SREG_C)
 
-inline void set_bit(u8 &dest,int bit,int value)
+// Set the given 'bit' of 'dest' to the given 'value'.
+// Zero for 'value' clears the bit, nonzero sets. Only the low 16 bits of
+// 'value' are effective.
+inline static void set_bit(u8 &dest, unsigned int bit, unsigned int value)
 {
-	if (value)
-		dest |= (1<<bit);
-	else
-		dest &= ~(1<<bit);
+	// Assume at most 16 bits input on value, makes it 0 or 1, the latter
+	// if the input was nonzero. The "& 1U" part is usually thrown away by
+	// the compiler (32 bits). The "& 0xFFFFU" part might also be thrown
+	// away depending on the input.
+	value = ((0U - (value & 0xFFFFU)) >> 31) & 1U;
+	dest  = dest & (~(1U << bit));
+	dest  = dest | (value << bit);
 }
+// Inverse set bit: Sets if value is zero, clears otherwise
+inline static void set_bit_inv(u8 &dest, unsigned int bit, unsigned int value)
+{
+	value = ((0U - (value & 0xFFFFU)) >> 31) & 1U;
+	dest  = dest | (1U << bit);
+	dest  = dest & (~(value << bit));
+}
+// Set bit using only the lowest bit of 'value'.
+inline static void set_bit_1(u8 &dest, unsigned int bit, unsigned int value)
+{
+	// The "& 1" on 'value' might be thrown away for suitable input
+	// If 'bit' is constant (inlining), it folds up well on optimizing.
+	dest  = dest & (~(1U << bit));
+	dest  = dest | ((0U - (value & 1U)) & (1U << bit));
+}
+
 
 // This computes both the half-carry (bit3) and full carry (bit7)
 #define BORROWS		(~Rd&Rr)|(Rr&R)|(R&~Rd)
@@ -146,32 +168,36 @@ inline void set_bit(u8 &dest,int bit,int value)
 
 #define UPDATE_HC_SUB \
 	CH = BORROWS; \
-	set_bit(SREG, SREG_H, CH & 0x8); \
-	set_bit(SREG, SREG_C, CH & 0x80)
+	set_bit_1(SREG, SREG_H, (CH & 0x08U) >> 3); \
+	set_bit_1(SREG, SREG_C, (CH & 0x80U) >> 7);
 #define UPDATE_HC_ADD \
 	CH = CARRIES; \
-	set_bit(SREG, SREG_H, CH & 0x8); \
-	set_bit(SREG, SREG_C, CH & 0x80)
+	set_bit_1(SREG, SREG_H, (CH & 0x08U) >> 3); \
+	set_bit_1(SREG, SREG_C, (CH & 0x80U) >> 7);
 
-#define UPDATE_H		set_bit(SREG, SREG_H, (CARRIES & 0x8))
-#define UPDATE_Z		set_bit(SREG, SREG_Z, !R)
-#define UPDATE_V_ADD	set_bit(SREG, SREG_V, ((Rd&Rr&~R)|(~Rd&~Rr&R)) & 0x80)
-#define UPDATE_V_SUB	set_bit(SREG, SREG_V, ((Rd&~Rr&~R)|(~Rd&Rr&R)) & 0x80)
-#define UPDATE_N		set_bit(SREG, SREG_N, R & 0x80)
-#define UPDATE_S		set_bit(SREG, SREG_S, BIT(SREG,SREG_N) ^ BIT(SREG,SREG_V))
+#define UPDATE_H		set_bit_1(SREG, SREG_H, (CARRIES & 0x8) >> 3)
+#define UPDATE_Z		set_bit_inv(SREG, SREG_Z, R)
+#define UPDATE_V_ADD	set_bit_1(SREG, SREG_V, (((Rd&Rr&~R)|(~Rd&~Rr&R)) & 0x80) >> 7)
+#define UPDATE_V_SUB	set_bit_1(SREG, SREG_V, (((Rd&~Rr&~R)|(~Rd&Rr&R)) & 0x80) >> 7)
+#define UPDATE_N		set_bit_1(SREG, SREG_N, (R & 0x80) >> 7)
+#define UPDATE_S		set_bit_1(SREG, SREG_S, BIT(SREG,SREG_N) ^ BIT(SREG,SREG_V))
 
 #define UPDATE_SVN_SUB	UPDATE_V_SUB; UPDATE_N; UPDATE_S
 #define UPDATE_SVN_ADD	UPDATE_V_ADD; UPDATE_N; UPDATE_S
 
 // Simplified version for logical insns.
+// If 7th bit of R is set:
+//     Sets N, sets S, clears V.
+// If 7th bit of R is clear:
+//     Clears N, clears S, clears V.
+// (Note: SREG_S, SREG_V, SREG_N are constants, so a lot is calculated by
+// preprocessor)
 #define UPDATE_SVN_LOGICAL \
-	if (R & 0x80) { /* Set N and S, clear V */ \
-		SREG = (SREG | (1<<SREG_N) | (1<<SREG_S)) & ~(1<<SREG_V); \
-	} else { /* Clear N and S and V */ \
-		SREG = (SREG & ~((1<<SREG_S)|(1<<SREG_V)|(1<<SREG_N))); \
-	}
+	SREG = \
+		(SREG & (~((1U << SREG_S) | (1U << SREG_V) | (1U << SREG_N)))) | \
+		(((0x7FU - (unsigned int)(R)) >> 8) & ((1U << SREG_S) | (1U << SREG_V)));
 
-#define UPDATE_CZ_MUL(x)		set_bit(SREG,SREG_C,x & 0x8000); set_bit(SREG,SREG_Z,!x)
+#define UPDATE_CZ_MUL(x)		set_bit_1(SREG,SREG_C,(x & 0x8000) >> 15); set_bit_inv(SREG,SREG_Z,x)
 
 #define CLEAR_Z		(SREG &= ~(1<<SREG_Z))
 #define SET_C		(SREG |= (1<<SREG_C))
@@ -861,31 +887,32 @@ u8 avr8::exec()
 	//Program counter must be incremented *after* GDB
 	pc++;
 
-	switch (insn >> 12) 
+
+	switch (insn >> 10)
 	{
-	case 0:
-	  /*0000 0000 0000 0000		NOP
-		0000 0001 dddd rrrr		MOVW Rd+1:Rd,Rr+1:R
-		0000 0010 dddd rrrr		MULS Rd,Rr
-		0000 0011 0ddd 0rrr		MULSU Rd,Rr (registers are in 16-23 range)
-		0000 0011 0ddd 1rrr		FMUL Rd,Rr (registers are in 16-23 range)
-		0000 0011 1ddd 0rrr		FMULS Rd,Rr
-		0000 0011 1ddd 1rrr		FMULSU Rd,Rr
-		0000 01rd dddd rrrr		CPC Rd,Rr
-		0000 10rd dddd rrrr		SBC Rd,Rr
-		0000 11rd dddd rrrr		ADD Rd,Rr (LSL is ADD Rd,Rd)*/
-		switch(insn >> 8)
+	case 0x00U:
+		// 0000 0000 0000 0000		NOP
+		// 0000 0001 dddd rrrr		MOVW Rd+1:Rd,Rr+1:R
+		// 0000 0010 dddd rrrr		MULS Rd,Rr
+		// 0000 0011 0ddd 0rrr		MULSU Rd,Rr (registers are in 16-23 range)
+		// 0000 0011 0ddd 1rrr		FMUL Rd,Rr (registers are in 16-23 range)
+		// 0000 0011 1ddd 0rrr		FMULS Rd,Rr
+		// 0000 0011 1ddd 1rrr		FMULSU Rd,Rr
+		switch (((insn >> 6) & 0xEU) | ((insn >> 3) & 0x1U))
 		{
-		case 0: /*NOP*/; 
+		case 0x0U: case 0x1U: case 0x2U: case 0x3U:
+			// 0000 0000 0000 0000		NOP
 			break;
-		case 1: /*MOVW*/ 
+		case 0x4U: case 0x5U: case 0x6U: case 0x7U:
+			// 0000 0001 dddd rrrr		MOVW Rd+1:Rd,Rr+1:R
 			// Don't use tab because the operand is really wide
 			Rd = D4 << 1; 
 			Rr = R4 << 1; 
 			r[Rd] = r[Rr]; 
 			r[Rd+1] = r[Rr+1]; 
 			break;
-		case 2: /*MULS*/ 
+		case 0x8U: case 0x9U: case 0xAU: case 0xBU:
+			// 0000 0010 dddd rrrr		MULS Rd,Rr
 			Rd = r[D4 + 16]; 
 			Rr = r[R4 + 16];
 			sTmp = (s8)Rd * (s8)Rr; 
@@ -894,576 +921,649 @@ u8 avr8::exec()
 			UPDATE_CZ_MUL(sTmp);
 			cycles=2;
 			break;
-		case 3: /*MULSU/FMULS/FMULSU*/ 
-			switch (insn & 0x88)
-			{
-			case 0x00:/*MULSU*/
-				Rd = r[D3 + 16];
-				Rr = r[R3 + 16]; 
-				sTmp = (s8)Rd * (u8)Rr; 
-				r0 = (u8)sTmp; 
-				r1 = (u8)(sTmp >> 8);
-				UPDATE_CZ_MUL(sTmp);
-				cycles=2;
-				break;
-			case 0x08:/*FMUL*/
-				Rd = r[D3 + 16];
-				Rr = r[R3 + 16]; 
-				uTmp = (u8)Rd * (u8)Rr; 
-				r0 = (u8)(uTmp << 1); 
-				r1 = (u8)(uTmp >> 7);
-				UPDATE_CZ_MUL(uTmp);
-				cycles=2;
-				break;
-			case 0x80:/*FMULS*/
-				Rd = r[D3 + 16];
-				Rr = r[R3 + 16]; 
-				sTmp = (s8)Rd * (s8)Rr; 
-				r0 = (u8)(sTmp << 1); 
-				r1 = (u8)(sTmp >> 7);
-				UPDATE_CZ_MUL(sTmp);
-				cycles=2;
-				break;
-			case 0x88:/*FMULSU*/
-				Rd = r[D3 + 16];
-				Rr = r[R3 + 16]; 
-				sTmp = (s8)Rd * (u8)Rr; 
-				r0 = (u8)(sTmp << 1); 
-				r1 = (u8)(sTmp >> 7);
-				UPDATE_CZ_MUL(sTmp);
-				cycles=2;
-				break;
-			}
+		case 0xCU:
+			// 0000 0011 0ddd 0rrr		MULSU Rd,Rr (registers are in 16-23 range)
+			Rd = r[D3 + 16];
+			Rr = r[R3 + 16]; 
+			sTmp = (s8)Rd * (u8)Rr; 
+			r0 = (u8)sTmp; 
+			r1 = (u8)(sTmp >> 8);
+			UPDATE_CZ_MUL(sTmp);
+			cycles=2;
 			break;
-		case 4: case 5: case 6: case 7: /*CPC*/
-			Rd = r[D5];
-			Rr = r[R5];
-			R = Rd - Rr - C;
-			UPDATE_HC_SUB; UPDATE_SVN_SUB; if (R) CLEAR_Z;
+		case 0xDU:
+			// 0000 0011 0ddd 1rrr		FMUL Rd,Rr (registers are in 16-23 range)
+			Rd = r[D3 + 16];
+			Rr = r[R3 + 16]; 
+			uTmp = (u8)Rd * (u8)Rr; 
+			r0 = (u8)(uTmp << 1); 
+			r1 = (u8)(uTmp >> 7);
+			UPDATE_CZ_MUL(uTmp);
+			cycles=2;
 			break;
-		case 8: case 9: case 10: case 11: /*SBC*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd - Rr - C;
-			UPDATE_HC_SUB; UPDATE_SVN_SUB; if (R) CLEAR_Z;
-			r[d] = R;
+		case 0xEU:
+			// 0000 0011 1ddd 0rrr		FMULS Rd,Rr
+			Rd = r[D3 + 16];
+			Rr = r[R3 + 16]; 
+			sTmp = (s8)Rd * (s8)Rr; 
+			r0 = (u8)(sTmp << 1); 
+			r1 = (u8)(sTmp >> 7);
+			UPDATE_CZ_MUL(sTmp);
+			cycles=2;
 			break;
-		case 12: case 13: case 14: case 15: /*ADD*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd + Rr;
-			UPDATE_HC_ADD; UPDATE_SVN_ADD; UPDATE_Z; 
-			r[d] = R;
+		default:
+			// 0000 0011 1ddd 1rrr		FMULSU Rd,Rr
+			Rd = r[D3 + 16];
+			Rr = r[R3 + 16]; 
+			sTmp = (s8)Rd * (u8)Rr; 
+			r0 = (u8)(sTmp << 1); 
+			r1 = (u8)(sTmp >> 7);
+			UPDATE_CZ_MUL(sTmp);
+			cycles=2;
 			break;
 		}
 		break;
-	case 1:
-	  /*0001 00rd dddd rrrr		CPSE Rd,Rr
-		0001 01rd dddd rrrr		CP Rd,Rr
-		0001 10rd dddd rrrr		SUB Rd,Rr
-		0001 11rd dddd rrrr		ADC Rd,Rr (ROL is ADC Rd,Rd)*/
-		switch ((insn >> 10) & 3)
+
+	case 0x01U:
+		// 0000 01rd dddd rrrr		CPC Rd,Rr
+		Rd = r[D5];
+		Rr = r[R5];
+		R = Rd - Rr - C;
+		UPDATE_HC_SUB; UPDATE_SVN_SUB; if (R) CLEAR_Z;
+		break;
+
+	case 0x02U:
+		// 0000 10rd dddd rrrr		SBC Rd,Rr
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd - Rr - C;
+		UPDATE_HC_SUB; UPDATE_SVN_SUB; if (R) CLEAR_Z;
+		r[d] = R;
+		break;
+
+	case 0x03U:
+		// 0000 11rd dddd rrrr		ADD Rd,Rr (LSL is ADD Rd,Rd)
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd + Rr;
+		UPDATE_HC_ADD; UPDATE_SVN_ADD; UPDATE_Z; 
+		r[d] = R;
+		break;
+
+	case 0x04U:
+		// 0001 00rd dddd rrrr		CPSE Rd,Rr
+		Rd = r[D5];
+		Rr = r[R5];
+		if (Rd == Rr)
 		{
-		case 0: /*CPSE*/
-			Rd = r[D5];
-			Rr = r[R5];
-			if (Rd == Rr)
-			{
-				uTmp = get_insn_size(progmem[pc]);
-				cycles += uTmp;
-				pc += uTmp;
-			}
-			break;
-		case 1: /*CP*/
-			Rd = r[D5];
-			Rr = r[R5];
-			R = Rd - Rr;
-			UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
-			break;
-		case 2: /*SUB*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd - Rr;
-			UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
-			r[d] = R;
-			break;
-		case 3: /*ADC*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd + Rr + C;
-			UPDATE_HC_ADD; UPDATE_SVN_ADD; UPDATE_Z; 
-			r[d] = R;
-			break;
+			uTmp = get_insn_size(progmem[pc]);
+			cycles += uTmp;
+			pc += uTmp;
 		}
 		break;
-	case 2:
-	  /*0010 00rd dddd rrrr		AND Rd,Rr (TST is AND Rd,Rd)
-		0010 01rd dddd rrrr		EOR Rd,Rr (CLR is EOR Rd,Rd)
-		0010 10rd dddd rrrr		OR Rd,Rr
-		0010 11rd dddd rrrr		MOV Rd,Rr*/
-		switch ((insn >> 10) & 3)
-		{
-		case 0: /*AND*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd & Rr;
-			UPDATE_SVN_LOGICAL; UPDATE_Z;
-			r[d] = R;
-			break;
-		case 1: /*EOR*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd ^ Rr;
-			UPDATE_SVN_LOGICAL; UPDATE_Z;
-			r[d] = R;
-			break;
-		case 2: /*OR*/
-			Rd = r[d = D5];
-			Rr = r[R5];
-			R = Rd | Rr;
-			UPDATE_SVN_LOGICAL; UPDATE_Z;
-			r[d] = R;
-			break;
-		case 3: /*MOV*/
-			r[D5]  = r[R5];
-			break;
-		}
+
+	case 0x05U:
+		// 0001 01rd dddd rrrr		CP Rd,Rr
+		Rd = r[D5];
+		Rr = r[R5];
+		R = Rd - Rr;
+		UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
 		break;
-	case 3: /*0011 KKKK dddd KKKK		CPI Rd,K */
+
+	case 0x06U:
+		// 0001 10rd dddd rrrr		SUB Rd,Rr
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd - Rr;
+		UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
+		r[d] = R;
+		break;
+
+	case 0x07U:
+		// 0001 11rd dddd rrrr		ADC Rd,Rr (ROL is ADC Rd,Rd)
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd + Rr + C;
+		UPDATE_HC_ADD; UPDATE_SVN_ADD; UPDATE_Z; 
+		r[d] = R;
+		break;
+
+	case 0x08U:
+		// 0010 00rd dddd rrrr		AND Rd,Rr (TST is AND Rd,Rd)
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd & Rr;
+		UPDATE_SVN_LOGICAL; UPDATE_Z;
+		r[d] = R;
+		break;
+
+	case 0x09U:
+		// 0010 01rd dddd rrrr		EOR Rd,Rr (CLR is EOR Rd,Rd)
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd ^ Rr;
+		UPDATE_SVN_LOGICAL; UPDATE_Z;
+		r[d] = R;
+		break;
+
+	case 0x0AU:
+		// 0010 10rd dddd rrrr		OR Rd,Rr
+		Rd = r[d = D5];
+		Rr = r[R5];
+		R = Rd | Rr;
+		UPDATE_SVN_LOGICAL; UPDATE_Z;
+		r[d] = R;
+		break;
+
+	case 0x0BU:
+		// 0010 11rd dddd rrrr		MOV Rd,Rr
+		r[D5]  = r[R5];
+		break;
+
+	case 0x0CU: case 0x0DU: case 0x0EU: case 0x0FU:
+		// 0011 KKKK dddd KKKK		CPI Rd,K
 		Rd = r[D4 + 16];
 		Rr = K8;
 		R = Rd - Rr;
 		UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
 		break;
-	case 4: /*0100 KKKK dddd KKKK		SBCI Rd,K */
+
+	case 0x10U: case 0x11U: case 0x12U: case 0x13U:
+		// 0100 KKKK dddd KKKK		SBCI Rd,K
 		Rd = r[d = D4 + 16];
 		Rr = K8;
 		R = Rd - Rr - C;
 		UPDATE_HC_SUB; UPDATE_SVN_SUB; if (R) CLEAR_Z;
 		r[d] = R;
 		break;
-	case 5: /*0101 KKKK dddd KKKK		SUBI Rd,K */
+
+	case 0x14U: case 0x15U: case 0x16U: case 0x17U:
+		// 0101 KKKK dddd KKKK		SUBI Rd,K
 		Rd = r[d = D4 + 16];
 		Rr = K8;
 		R = Rd - Rr;
 		UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
 		r[d] = R;
 		break;
-	case 6: /*0110 KKKK dddd KKKK		ORI Rd,K (same as SBR insn) */
+
+	case 0x18U: case 0x19U: case 0x1AU: case 0x1BU:
+		// 0110 KKKK dddd KKKK		ORI Rd,K (same as SBR insn)
 		Rd = r[d = D4 + 16];
 		Rr = K8;
 		R = Rd | Rr;
 		UPDATE_SVN_LOGICAL; UPDATE_Z;
 		r[d] = R;
 		break;
-	case 7: /*0111 KKKK dddd KKKK		ANDI Rd,K (CBR is ANDI with K complemented) */
+
+	case 0x1CU: case 0x1DU: case 0x1EU: case 0x1FU:
+		// 0111 KKKK dddd KKKK		ANDI Rd,K (CBR is ANDI with K complemented)
 		Rd = r[d = D4 + 16];
 		Rr = K8;
 		R = Rd & Rr;
 		UPDATE_SVN_LOGICAL; UPDATE_Z;
 		r[d] = R;
 		break;
-	case 8: case 10:
-	  /*10q0 qq0d dddd 0qqq		LD Rd,Z+q
-		10q0 qq0d dddd 1qqq		LD Rd,Y+q
-		10q0 qq1d dddd 0qqq		ST Z+q,Rd
-		10q0 qq1d dddd 1qqq		ST Y+q,Rd */
-		Rd = D5;
-		Rr = (insn & 7) | ((insn >> 7) & 0x18) | ((insn >> 8) & 0x20);
-		uTmp = ((insn & 0x8)? Y : Z) + Rr;
-		cycles=2;
-		if (insn & 0x200)	/*ST*/
-		{
-			write_sram(uTmp, r[Rd]);
-		}
-		else /*LD*/
-		{
-			r[Rd] = read_sram_ld(uTmp);
-		}
 
-		break;
-	case 9:
-		switch ((insn>>8) & 15)
+	case 0x20U: case 0x21U: case 0x22U: case 0x23U:
+	case 0x28U: case 0x29U: case 0x2AU: case 0x2BU:
+		// 10q0 qq0d dddd 0qqq		LD Rd,Z+q
+		// 10q0 qq0d dddd 1qqq		LD Rd,Y+q
+		// 10q0 qq1d dddd 0qqq		ST Z+q,Rd
+		// 10q0 qq1d dddd 1qqq		ST Y+q,Rd
+		Rd = D5;
+		Rr = (insn & 7U) | ((insn >> 7) & 0x18U) | ((insn >> 8) & 0x20U);
+		cycles=2; // Note: read_sram_ld may adjust further it!
+		switch (((insn >> 8) & 2U) | ((insn >> 3) & 1U))
 		{
-		case 0: case 1:
-		  /*1001 000d dddd 0000		LDS Rd,k (next word is rest of address)
-			1001 000d dddd 0001		LD Rd,Z+
-			1001 000d dddd 0010		LD Rd,-Z
-			1001 000d dddd 0100		LPM Rd,Z
-			1001 000d dddd 0101		LPM Rd,Z+
-			1001 000d dddd 0110		ELPM Rd,Z
-			1001 000d dddd 0111		ELPM Rd,Z+
-			1001 000d dddd 1001		LD Rd,Y+
-			1001 000d dddd 1010		LD Rd,-Y
-			1001 000d dddd 1100		LD rd,X
-			1001 000d dddd 1101		LD rd,X+
-			1001 000d dddd 1110		LD rd,-X
-			1001 000d dddd 1111		POP Rd */
-			switch (insn & 15)
-			{
-			case 0: // LDS Rd,k
-				cycles=2;
-				r[D5] = read_sram_ld(progmem[pc++]);
-				break;
-			case 1:	// LD Rd,Z+
-				cycles=2;
-				r[D5] = read_sram_ld(Z);
-				INC_Z;
-				break;
-			case 2: // LD Rd,-Z
-				DEC_Z;
-				cycles=2;
-				r[D5] = read_sram_ld(Z);
-				break;
-			case 4: // LPM Rd,Z
-				r[D5] = read_progmem(Z);
-				cycles=3;
-				break;
-			case 5: //LPM Rd,Z+
-				r[D5] = read_progmem(Z);
-				INC_Z;
-				cycles=3;
-				break;
-			case 6: //ELPM Rd,Z
-				r[D5] = read_progmem(Z);
-				cycles=3;
-				break;
-			case 7: //ELPM Rd,Z+
-				r[D5] = read_progmem(Z);
-				INC_Z;
-				cycles=3;
-				break;
-			case 9: //LD Rd,Y+
-				r[D5] = read_sram_ld(Y);
-				INC_Y;
-				cycles=2;
-				break;
-			case 10: //LD Rd,-Y
-				DEC_Y;
-				cycles=2;
-				r[D5] = read_sram_ld(Y);
-				break;
-			case 12: //LD Rd,X
-				cycles=2;
-				r[D5] = read_sram_ld(X);
-				break;
-			case 13: //LD Rd,X+
-				cycles=2;
-				r[D5] = read_sram_ld(X);
-				INC_X;
-				break;
-			case 14: //LD Rd,-X
-				DEC_X;
-				cycles=2;
-				r[D5] = read_sram_ld(X);
-				break;
-			case 15: //POP Rd
-				INC_SP;
-				r[D5] = read_sram(SP);
-				cycles=2;
-				break;
-			default:
-				ILLEGAL_OP;
-				break;
-			}
+		case 0U:
+			// 10q0 qq0d dddd 0qqq		LD Rd,Z+q
+			r[Rd] = read_sram_ld(Z + Rr);
 			break;
-		case 2: case 3:
-		  /*1001 001d dddd 0000		STS k,Rr (next word is rest of address)
-			1001 001r rrrr 0001		ST Z+,Rr
-			1001 001r rrrr 0010		ST -Z,Rr
-			1001 001r rrrr 1001		ST Y+,Rr
-			1001 001r rrrr 1010		ST -Y,Rr
-			1001 001r rrrr 1100		ST X,Rr
-			1001 001r rrrr 1101		ST X+,Rr
-			1001 001r rrrr 1110		ST -X,Rr
-			1001 001d dddd 1111		PUSH Rd */
+		case 1U:
+			// 10q0 qq0d dddd 1qqq		LD Rd,Y+q
+			r[Rd] = read_sram_ld(Y + Rr);
+			break;
+		case 2U:
+			// 10q0 qq1d dddd 0qqq		ST Z+q,Rd
+			write_sram(Z + Rr, r[Rd]);
+			break;
+		default:
+			// 10q0 qq1d dddd 1qqq		ST Y+q,Rd
+			write_sram(Y + Rr, r[Rd]);
+			break;
+		}
+		break;
+
+	case 0x24U:
+		// 1001 000d dddd 0000		LDS Rd,k (next word is rest of address)
+		// 1001 000d dddd 0001		LD Rd,Z+
+		// 1001 000d dddd 0010		LD Rd,-Z
+		// 1001 000d dddd 0100		LPM Rd,Z
+		// 1001 000d dddd 0101		LPM Rd,Z+
+		// 1001 000d dddd 0110		ELPM Rd,Z
+		// 1001 000d dddd 0111		ELPM Rd,Z+
+		// 1001 000d dddd 1001		LD Rd,Y+
+		// 1001 000d dddd 1010		LD Rd,-Y
+		// 1001 000d dddd 1100		LD rd,X
+		// 1001 000d dddd 1101		LD rd,X+
+		// 1001 000d dddd 1110		LD rd,-X
+		// 1001 000d dddd 1111		POP Rd
+		// 1001 001d dddd 0000		STS k,Rr (next word is rest of address)
+		// 1001 001r rrrr 0001		ST Z+,Rr
+		// 1001 001r rrrr 0010		ST -Z,Rr
+		// 1001 001r rrrr 1001		ST Y+,Rr
+		// 1001 001r rrrr 1010		ST -Y,Rr
+		// 1001 001r rrrr 1100		ST X,Rr
+		// 1001 001r rrrr 1101		ST X+,Rr
+		// 1001 001r rrrr 1110		ST -X,Rr
+		// 1001 001d dddd 1111		PUSH Rd
+		switch (((insn >> 5) & 0x10U) | (insn & 0xFU))
+		{
+		case 0x00U:
+			// 1001 000d dddd 0000		LDS Rd,k (next word is rest of address)
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(progmem[pc++]);
+			break;
+		case 0x01U:
+			// 1001 000d dddd 0001		LD Rd,Z+
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(Z);
+			INC_Z;
+			break;
+		case 0x02U:
+			// 1001 000d dddd 0010		LD Rd,-Z
+			DEC_Z;
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(Z);
+			break;
+		case 0x04U:
+			// 1001 000d dddd 0100		LPM Rd,Z
+			r[D5] = read_progmem(Z);
+			cycles=3;
+			break;
+		case 0x05U:
+			// 1001 000d dddd 0101		LPM Rd,Z+
+			r[D5] = read_progmem(Z);
+			INC_Z;
+			cycles=3;
+			break;
+		case 0x06U:
+			// 1001 000d dddd 0110		ELPM Rd,Z
+			r[D5] = read_progmem(Z);
+			cycles=3;
+			break;
+		case 0x07U:
+			// 1001 000d dddd 0111		ELPM Rd,Z+
+			r[D5] = read_progmem(Z);
+			INC_Z;
+			cycles=3;
+			break;
+		case 0x09U:
+			// 1001 000d dddd 1001		LD Rd,Y+
+			r[D5] = read_sram_ld(Y);
+			INC_Y;
+			cycles=2; // TODO: Sure no bug here??! (read_sram_ld wants to alter it!!)
+			break;
+		case 0x0AU:
+			// 1001 000d dddd 1010		LD Rd,-Y
+			DEC_Y;
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(Y);
+			break;
+		case 0x0CU:
+			// 1001 000d dddd 1100		LD rd,X
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(X);
+			break;
+		case 0x0DU:
+			// 1001 000d dddd 1101		LD rd,X+
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(X);
+			INC_X;
+			break;
+		case 0x0EU:
+			// 1001 000d dddd 1110		LD rd,-X
+			DEC_X;
+			cycles=2; // Note: read_sram_ld may adjust further it!
+			r[D5] = read_sram_ld(X);
+			break;
+		case 0x0FU:
+			// 1001 000d dddd 1111		POP Rd
+			INC_SP;
+			r[D5] = read_sram(SP);
 			cycles=2;
-			switch (insn & 15)
-			{
-			case 0: //STS
-				write_sram(progmem[pc++],r[D5]);
-				break;
-			case 1: //ST Z+,Rs
-				write_sram(Z,r[D5]);
-				INC_Z;
-				break;
-			case 2: //ST -Z,Rs
-				DEC_Z;
-				write_sram(Z,r[D5]);
-				break;
-			case 9: //ST Y+,Rs
-				write_sram(Y,r[D5]);
-				INC_Y;
-				break;
-			case 10: //ST -Y,Rs
-				DEC_Y;
-				write_sram(Y,r[D5]);
-				break;
-			case 12: //ST X,Rs
-				write_sram(X,r[D5]);
-				break;
-			case 13: //ST X+,Rs
-				write_sram(X,r[D5]);
-				INC_X;
-				break;
-			case 14: //ST -X,Rs
-				DEC_X;
-				write_sram(X,r[D5]);
-				break;
-			case 15: //PUSH Rs
-				write_sram(SP,r[D5]);
-				DEC_SP;
-				break;
-			default:
-				ILLEGAL_OP;
-				break;
-			}
 			break;
-		case 4: case 5:
-		  /*1001 0100 0000 1001		IJMP (jump thru Z register)
-			1001 0100 0001 1001		EIJMP (probably not on 644)
-			1001 0100 0sss 1000		BSET s (SEC, etc are aliases with sss implicit)
-			1001 0100 1sss 1000		BCLR s (CLC, etc are aliases with sss implicit)
-			1001 0100 KKKK 1011		DES (probably not on 644)
-			1001 0101 0000 1000		RET
-			1001 0101 0000 1001		ICALL (call thru Z register)
-			1001 0101 0001 1000		RETI
-			1001 0101 0001 1001		EICALL (probably not on 644)
-			1001 0101 1000 1000		SLEEP
-			1001 0101 1001 1000		BREAK
-			1001 0101 1010 1000		WDR
-			1001 0101 1100 1000		LPM (r0 implied, why is this special?)
-			1001 0101 1101 1000		ELPM (r0 implied)
-			1001 0101 1110 1000		SPM Z (writes R1:R0)
-		    1001 010d dddd 0000		COM Rd
-			1001 010d dddd 0001		NEG Rd
-			1001 010d dddd 0010		SWAP Rd
-			1001 010d dddd 0011		INC Rd
-			1001 010d dddd 0101		ASR Rd
-			1001 010d dddd 0110		LSR Rd
-			1001 010d dddd 0111		ROR Rd
-			1001 010d dddd 1010		DEC Rd
-			1001 010k kkkk 110k		JMP k (next word is rest of address)
-			1001 010k kkkk 111k		CALL k (next word is rest of address) */
-			// Bunch of weird cases here, check for them first and then re-decode.
-			switch (insn)
+		case 0x10U:
+			// 1001 001d dddd 0000		STS k,Rr (next word is rest of address)
+			cycles=2;
+			write_sram(progmem[pc++],r[D5]);
+			break;
+		case 0x11U:
+			// 1001 001r rrrr 0001		ST Z+,Rr
+			cycles=2;
+			write_sram(Z,r[D5]);
+			INC_Z;
+			break;
+		case 0x12U:
+			// 1001 001r rrrr 0010		ST -Z,Rr
+			DEC_Z;
+			cycles=2;
+			write_sram(Z,r[D5]);
+			break;
+		case 0x19U:
+			// 1001 001r rrrr 1001		ST Y+,Rr
+			cycles=2;
+			write_sram(Y,r[D5]);
+			INC_Y;
+			break;
+		case 0x1AU:
+			// 1001 001r rrrr 1010		ST -Y,Rr
+			DEC_Y;
+			cycles=2;
+			write_sram(Y,r[D5]);
+			break;
+		case 0x1CU:
+			// 1001 001r rrrr 1100		ST X,Rr
+			cycles=2;
+			write_sram(X,r[D5]);
+			break;
+		case 0x1DU:
+			// 1001 001r rrrr 1101		ST X+,Rr
+			cycles=2;
+			write_sram(X,r[D5]);
+			INC_X;
+			break;
+		case 0x1EU:
+			// 1001 001r rrrr 1110		ST -X,Rr
+			DEC_X;
+			cycles=2;
+			write_sram(X,r[D5]);
+			break;
+		case 0x1FU:
+			// 1001 001d dddd 1111		PUSH Rd
+			cycles=2;
+			write_sram(SP,r[D5]);
+			DEC_SP;
+			break;
+		default:
+			// Illegal op.
+			ILLEGAL_OP;
+			break;
+		}
+		break;
+
+	case 0x25U:
+		// 1001 010d dddd 0000		COM Rd
+		// 1001 010d dddd 0001		NEG Rd
+		// 1001 010d dddd 0010		SWAP Rd
+		// 1001 010d dddd 0011		INC Rd
+		// 1001 010d dddd 0101		ASR Rd
+		// 1001 010d dddd 0110		LSR Rd
+		// 1001 010d dddd 0111		ROR Rd
+		// 1001 010d dddd 1010		DEC Rd
+		// 1001 010k kkkk 110k		JMP k (next word is rest of address)
+		// 1001 010k kkkk 111k		CALL k (next word is rest of address)
+		// 1001 0100 0sss 1000		BSET s (SEC, etc are aliases with sss implicit)
+		// 1001 0100 1sss 1000		BCLR s (CLC, etc are aliases with sss implicit)
+		// 1001 0100 0000 1001		IJMP (jump thru Z register)
+		// 1001 0100 0001 1001		EIJMP (probably not on 644)
+		// 1001 0100 KKKK 1011		DES (probably not on 644)
+		// 1001 0101 0000 1000		RET
+		// 1001 0101 0000 1001		ICALL (call thru Z register)
+		// 1001 0101 0001 1000		RETI
+		// 1001 0101 0001 1001		EICALL (probably not on 644)
+		// 1001 0101 1000 1000		SLEEP
+		// 1001 0101 1001 1000		BREAK
+		// 1001 0101 1010 1000		WDR
+		// 1001 0101 1100 1000		LPM (r0 implied, why is this special?)
+		// 1001 0101 1101 1000		ELPM (r0 implied)
+		// 1001 0101 1110 1000		SPM Z (writes R1:R0)
+		// 1001 0110 KKdd KKKK		ADIW Rd+1:Rd,K   (16-bit add to upper four register pairs)
+		// 1001 0111 KKdd KKKK		SBIW Rd+1:Rd,K
+		switch (((insn >> 4) & 0x30U) | (insn & 0xFU))
+		{
+		case 0x00U: case 0x10U:
+			// 1001 010d dddd 0000		COM Rd
+			r[D5] = R = ~r[D5];
+			UPDATE_SVN_LOGICAL; UPDATE_Z; SET_C;
+			break;
+		case 0x01U: case 0x11U:
+			// 1001 010d dddd 0001		NEG Rd
+			Rr = r[D5];
+			Rd = 0;
+			r[D5] = R = Rd - Rr;
+			UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
+			break;
+		case 0x02U: case 0x12U:
+			// 1001 010d dddd 0010		SWAP Rd
+			Rd = r[D5];
+			r[D5] = (Rd >> 4) | (Rd << 4);
+			break;
+		case 0x03U: case 0x13U:
+			// 1001 010d dddd 0011		INC Rd
+			R = ++r[D5];
+			UPDATE_N;
+			set_bit_inv(SREG,SREG_V,(unsigned int)(R) - 0x80U);
+			UPDATE_S;
+			UPDATE_Z;
+			break;
+		case 0x05U: case 0x15U:
+			// 1001 010d dddd 0101		ASR Rd
+			Rd = r[D5];
+			set_bit_1(SREG,SREG_C,Rd&1);
+			r[D5] = R = (Rd >> 1) | (Rd & 0x80);
+			UPDATE_N;
+			set_bit_1(SREG,SREG_V,(R>>7)^(Rd&1));
+			UPDATE_S;
+			UPDATE_Z;
+			break;
+		case 0x06U: case 0x16U:
+			// 1001 010d dddd 0110		LSR Rd
+			Rd = r[D5];
+			set_bit_1(SREG,SREG_C,Rd&1);
+			r[D5] = R = (Rd >> 1);
+			UPDATE_N;
+			set_bit_1(SREG,SREG_V,Rd&1);
+			UPDATE_S;
+			UPDATE_Z;
+			break;
+		case 0x07U: case 0x17U:
+			// 1001 010d dddd 0111		ROR Rd
+			Rd = r[D5];
+			r[D5] = R = (Rd >> 1) | ((SREG&1)<<7);
+			set_bit_1(SREG,SREG_C,Rd&1);
+			UPDATE_N;
+			set_bit_1(SREG,SREG_V,(R>>7)^(Rd&1));
+			UPDATE_S;
+			UPDATE_Z;
+			break;
+		case 0x0AU: case 0x1AU:
+			// 1001 010d dddd 1010		DEC Rd
+			R = --r[D5];
+			UPDATE_N;
+			set_bit_inv(SREG,SREG_V,(unsigned int)(R) - 0x7FU);
+			UPDATE_S;
+			UPDATE_Z;
+			break;
+		case 0x0CU: case 0x0DU: case 0x1CU: case 0x1DU:
+			// 1001 010k kkkk 110k		JMP k (next word is rest of address)
+			// Note: 64K progmem, so 'k' in first insn word is unused
+			pc = progmem[pc];
+			cycles = 3;
+			break;
+		case 0x0EU: case 0x0FU: case 0x1EU: case 0x1FU:
+			// 1001 010k kkkk 111k		CALL k (next word is rest of address)
+			// Note: 64K progmem, so 'k' in first insn word is unused
+			write_sram(SP,(pc+1));
+			DEC_SP;
+			write_sram(SP,(pc+1)>>8);
+			DEC_SP;
+			pc = progmem[pc];
+			cycles = 4;
+			break;
+		case 0x08U:
+			// 1001 0100 0sss 1000		BSET s (SEC, etc are aliases with sss implicit)
+			// 1001 0100 1sss 1000		BCLR s (CLC, etc are aliases with sss implicit)
+			Rd = (insn >> 4) & 7U;
+			SREG |= (1U << Rd);
+			SREG &= ~(((insn & 0x80U) >> 7) << Rd);
+			break;
+		case 0x09U:
+			// 1001 0100 0000 1001		IJMP (jump thru Z register)
+			// 1001 0100 0001 1001		EIJMP (probably not on 644)
+			pc = Z;
+			cycles = 2;
+			break;
+		case 0x0BU:
+			// 1001 0100 KKKK 1011		DES (probably not on 644)
+			// no operation
+			break;
+		case 0x18U:
+			// 1001 0101 0000 1000		RET
+			// 1001 0101 0001 1000		RETI
+			// 1001 0101 1000 1000		SLEEP
+			// 1001 0101 1001 1000		BREAK
+			// 1001 0101 1010 1000		WDR
+			// 1001 0101 1100 1000		LPM (r0 implied, why is this special?)
+			// 1001 0101 1101 1000		ELPM (r0 implied)
+			// 1001 0101 1110 1000		SPM Z (writes R1:R0)
+			switch ((insn >> 4) & 0xFU)
 			{
-			case 0x9409: //IJMP
-			    pc = Z;
-			    cycles = 2;
-			    break;
-			case 0x940C: // JMP; relies on fact that upper k bits are always zero!
-			    pc = progmem[pc];
-			    cycles = 3;
-			    break;
-			case 0x940E: // CALL; relies on fact that upper k bits are always zero!
-			    write_sram(SP,(pc+1));
-			    DEC_SP;
-			    write_sram(SP,(pc+1)>>8);
-			    DEC_SP;
-			    pc = progmem[pc];
-			    cycles = 4;
-			    break;
-			case 0x9419: //EIJMP
-			    pc = Z;
-			    cycles = 2;
-			    break;
-			case 0x9508: //RET
-			    INC_SP;
-			    pc = read_sram(SP) << 8;
-			    INC_SP;
-			    pc |= read_sram(SP);
-			    cycles = 4;
-			    break;
-			case 0x9509: //ICALL
-			    write_sram(SP,u8(pc));
-			    DEC_SP;
-			    write_sram(SP,(pc)>>8);
-			    DEC_SP;
-			    pc = Z;
-			    cycles = 3;
-			    break;
-			case 0x9518: //RETI
-			    INC_SP;
-			    pc = read_sram(SP) << 8;
-			    INC_SP;
-			    pc |= read_sram(SP);
-			    cycles = 4;
-			    SREG |= (1<<SREG_I);
-			    break;
-			case 0x9519: //EICALL
-			    write_sram(SP,u8(pc));
-			    DEC_SP;
-			    write_sram(SP,(pc)>>8);
-			    DEC_SP;
-			    pc = Z;
-			    cycles = 3;
-			    break;
-			case 0x9588: //SLEEP
+			case 0x0U:
+				// 1001 0101 0000 1000		RET
+				INC_SP;
+				pc = read_sram(SP) << 8;
+				INC_SP;
+				pc |= read_sram(SP);
+				cycles = 4;
+				break;
+			case 0x1U:
+				// 1001 0101 0001 1000		RETI
+				INC_SP;
+				pc = read_sram(SP) << 8;
+				INC_SP;
+				pc |= read_sram(SP);
+				cycles = 4;
+				SREG |= (1<<SREG_I);
+				//--interruptLevel;
+				break;
+			case 0x8U:
+				// 1001 0101 1000 1000		SLEEP
 				elapsedCyclesSleep=cycleCounter-lastCyclesSleep;
 				lastCyclesSleep=cycleCounter;
-			    break;
-			case 0x9598: //BREAK
-			    // no operation
-			    break;
-			case 0x95A8: //WDR
-
+				break;
+			case 0x9U:
+				// 1001 0101 1001 1000		BREAK
+				// no operation
+				break;
+			case 0xAU:
+				// 1001 0101 1010 1000		WDR
 				//watchdog is based on a RC oscillator
 				//so add some random variation to simulate entropy
 				watchdogTimer=rand()%1024;
-
-			    if(prevWDR){
-			        printf("WDR measured %u cycles\n", cycleCounter - prevWDR);
-			        prevWDR = 0;
-			    }else{
-			    	prevWDR = cycleCounter + 1;
-			    }
-
-			break;
-			case 0x95C8: //LPM r0,Z
-			    r0 = read_progmem(Z);
-			    cycles = 3;
-			    break;
-			case 0x95D8: //ELPM r0,Z
-			    r0 = read_progmem(Z);
-			    cycles = 3;
-			    break;
-			case 0x95E8: //SPM
-			    if (Z >= progSize/2)
+				if(prevWDR){
+					printf("WDR measured %u cycles\n", cycleCounter - prevWDR);
+					prevWDR = 0;
+				}else{
+					prevWDR = cycleCounter + 1;
+				}
+				break;
+			case 0xCU:
+				// 1001 0101 1100 1000		LPM (r0 implied, why is this special?)
+				r0 = read_progmem(Z);
+				cycles = 3;
+				break;
+			case 0xDU:
+				// 1001 0101 1101 1000		ELPM (r0 implied)
+				r0 = read_progmem(Z);
+				cycles = 3;
+				break;
+			case 0xEU:
+				// 1001 0101 1110 1000		SPM Z (writes R1:R0)
+				if (Z >= progSize/2)
 				{
 					fprintf(stderr,"illegal write to progmem addr %x\n",Z);
-                    shutdown(1);
-				}
-				else
+					shutdown(1);
+				}else{
 					progmem[Z] = r0 | (r1<<8);
-			    cycles = 4; // undocumented?!?!?
-			    break;
-			default:
-			    /*1001 010d dddd 0000		COM Rd
-				1001 010d dddd 0001		NEG Rd
-				1001 010d dddd 0010		SWAP Rd
-				1001 010d dddd 0011		INC Rd
-				1001 010d dddd 0101		ASR Rd
-				1001 010d dddd 0110		LSR Rd
-				1001 010d dddd 0111		ROR Rd
-				1001 0100 0sss 1000		BSET s (SEC, etc are aliases with sss implicit)
-				1001 0100 1sss 1000		BCLR s (CLC, etc are aliases with sss implicit)
-				1001 010d dddd 1010		DEC Rd */
-			    switch (insn & 15)
-				{
-				case 0: //COM Rd
-					r[D5] = R = ~r[D5];
-					UPDATE_SVN_LOGICAL; UPDATE_Z; SET_C;
-					break;
-				case 1: //NEG Rd
-					Rr = r[D5];
-					Rd = 0;
-					r[D5] = R = Rd - Rr;
-					UPDATE_HC_SUB; UPDATE_SVN_SUB; UPDATE_Z;
-					break;
-				case 2: //SWAP Rd
-					Rd = r[D5];
-					r[D5] = (Rd >> 4) | (Rd << 4);
-					break;
-				case 3: //INC Rd
-					R = ++r[D5];
-					UPDATE_N;
-					set_bit(SREG,SREG_V,R==0x80);
-					UPDATE_S;
-					UPDATE_Z;
-					break;
-				case 5: //ASR Rd
-					Rd = r[D5];
-					set_bit(SREG,SREG_C,Rd&1);
-					r[D5] = R = (Rd >> 1) | (Rd & 0x80);
-					UPDATE_N;
-					set_bit(SREG,SREG_V,(R>>7)^(Rd&1));
-					UPDATE_S;
-					UPDATE_Z;
-					break;
-				case 6: //LSR Rd
-					Rd = r[D5];
-					set_bit(SREG,SREG_C,Rd&1);
-					r[D5] = R = (Rd >> 1);
-					UPDATE_N;
-					set_bit(SREG,SREG_V,Rd&1);
-					UPDATE_S;
-					UPDATE_Z;
-					break;
-				case 7: //ROR Rd
-					Rd = r[D5];
-					r[D5] = R = (Rd >> 1) | ((SREG&1)<<7);
-					set_bit(SREG,SREG_C,Rd&1);
-					UPDATE_N;
-					set_bit(SREG,SREG_V,(R>>7)^(Rd&1));
-					UPDATE_S;
-					UPDATE_Z;
-					break;
-				case 8: //Clear/Set flags in SREG
-					Rd = (insn>>4)&7;
-					if (insn & 0x80)
-					{
-						//CLx,"CZNVSHTI" CLI
-						SREG &= ~(1<<Rd);
-					}
-					else
-					{
-						//SEx,"CZNVSHTI" SEI
-						SREG |= (1<<Rd);
-					}
-					break;
-				case 10: //DEC Rd
-					R = --r[D5];
-					UPDATE_N;
-					set_bit(SREG,SREG_V,R==0x7F);
-					UPDATE_S;
-					UPDATE_Z;
-					break;
-				default:
-					ILLEGAL_OP;
-					break;
 				}
-			    break;
+				cycles = 4; // undocumented?!?!?
+				break;
+			default:
+				// Illegal op.
+				ILLEGAL_OP;
+				break;
 			}
 			break;
-		case 6:
-		  /*1001 0110 KKdd KKKK		ADIW Rd+1:Rd,K   (16-bit add to upper four register pairs) */
+		case 0x19U:
+			// 1001 0101 0000 1001		ICALL (call thru Z register)
+			// 1001 0101 0001 1001		EICALL (probably not on 644)
+			write_sram(SP,u8(pc));
+			DEC_SP;
+			write_sram(SP,(pc)>>8);
+			DEC_SP;
+			pc = Z;
+			cycles = 3;
+			break;
+		case 0x20U: case 0x21U: case 0x22U: case 0x23U:
+		case 0x24U: case 0x25U: case 0x26U: case 0x27U:
+		case 0x28U: case 0x29U: case 0x2AU: case 0x2BU:
+		case 0x2CU: case 0x2DU: case 0x2EU: case 0x2FU:
+			// 1001 0110 KKdd KKKK		ADIW Rd+1:Rd,K   (16-bit add to upper four register pairs)
 			Rd = ((insn >> 3) & 0x6) + 24;
 			Rr = ((insn >> 2) & 0x30) | (insn & 0xF);
 			Rd16 = r[Rd] | (r[Rd+1]<<8);
 			R16 = Rd16 + Rr;
 			r[Rd] = (u8)R16;
 			r[Rd+1] = (u8)(R16>>8);
-			set_bit(SREG,SREG_V,(~Rd16&R16)&0x8000);
-			set_bit(SREG,SREG_N,R16&0x8000);
+			set_bit_1(SREG,SREG_V,((~Rd16&R16)&0x8000) >> 15);
+			set_bit_1(SREG,SREG_N,(R16&0x8000) >> 15);
 			UPDATE_S;
-			set_bit(SREG,SREG_Z,!R16);
-			set_bit(SREG,SREG_C,(~R16&Rd16)&0x8000);
+			set_bit_inv(SREG,SREG_Z,R16);
+			set_bit_1(SREG,SREG_C,((~R16&Rd16)&0x8000) >> 15);
 			cycles=2;
 			break;
-		case 7:
-		  /*1001 0111 KKdd KKKK		SBIW Rd+1:Rd,K */
+		case 0x30U: case 0x31U: case 0x32U: case 0x33U:
+		case 0x34U: case 0x35U: case 0x36U: case 0x37U:
+		case 0x38U: case 0x39U: case 0x3AU: case 0x3BU:
+		case 0x3CU: case 0x3DU: case 0x3EU: case 0x3FU:
+			// 1001 0111 KKdd KKKK		SBIW Rd+1:Rd,K
 			Rd = ((insn >> 3) & 0x6) + 24;
 			Rr = ((insn >> 2) & 0x30) | (insn & 0xF);
 			Rd16 = r[Rd] | (r[Rd+1]<<8);
 			R16 = Rd16 - Rr;
 			r[Rd] = (u8)R16;
 			r[Rd+1] = (u8)(R16>>8);
-			set_bit(SREG,SREG_V,(Rd16&~R16)&0x8000);
-			set_bit(SREG,SREG_N,R16&0x8000);
+			set_bit_1(SREG,SREG_V,((Rd16&~R16)&0x8000) >> 15);
+			set_bit_1(SREG,SREG_N,(R16&0x8000) >> 15);
 			UPDATE_S;
-			set_bit(SREG,SREG_Z,!R16);
-			set_bit(SREG,SREG_C,(R16&~Rd16)&0x8000);
+			set_bit_inv(SREG,SREG_Z,R16);
+			set_bit_1(SREG,SREG_C,((R16&~Rd16)&0x8000) >> 15);
 			cycles=2;
 			break;
-		case 8:
-		  /*1001 1000 AAAA Abbb		CBI A,b */
+		default:
+			// Illegal op.
+			ILLEGAL_OP;
+			break;
+		}
+		break;
+
+	case 0x26U:
+		// 1001 1000 AAAA Abbb		CBI A,b
+		// 1001 1001 AAAA Abbb		SBIC A,b
+		// 1001 1010 AAAA Abbb		SBI A,b
+		// 1001 1011 AAAA Abbb		SBIS A,b
+		switch ((insn >> 8) & 3U)
+		{
+		case 0U:
+			// 1001 1000 AAAA Abbb		CBI A,b
 			Rd = (insn >> 3) & 31;
+			// TODO: Sure no bug here??! (see SBI below!!)
 			write_io(Rd, read_io(Rd) & ~(1<<(insn&7)));
 			cycles=2;
 			break;
-		case 9:
-		  /*1001 1001 AAAA Abbb		SBIC A,b */
+		case 1U:
+			// 1001 1001 AAAA Abbb		SBIC A,b
 			Rd = (insn >> 3) & 31;
 			if (!(read_io(Rd) & (1<<(insn&7))))
 			{
@@ -1472,14 +1572,14 @@ u8 avr8::exec()
 				pc += uTmp;
 			}
 			break;
-		case 10:
-		  /*1001 1010 AAAA Abbb		SBI A,b */
+		case 2U:
+			// 1001 1010 AAAA Abbb		SBI A,b
 			Rd = (insn >> 3) & 31;
 			cycles=2; //may be incremented if accessing EEPROM registers
 			write_io(Rd, read_io(Rd) | (1<<(insn&7)));
 			break;
-		case 11:
-		  /*1001 1011 AAAA Abbb		SBIS A,b */
+		default:
+			// 1001 1011 AAAA Abbb		SBIS A,b
 			Rd = (insn >> 3) & 31;
 			if (read_io(Rd) & (1<<(insn&7)))
 			{
@@ -1488,37 +1588,42 @@ u8 avr8::exec()
 				pc += uTmp;
 			}
 			break;
-		case 12: case 13: case 14: case 15:
-		  /*1001 11rd dddd rrrr		MUL Rd,Rr */
-			Rd = r[D5];
-			Rr = r[R5];
-			uTmp = Rd * Rr; 
-			r0 = (u8)uTmp; 
-			r1 = (u8)(uTmp >> 8);
-			UPDATE_CZ_MUL(uTmp);
-			cycles=2;
-			break;
 		}
 		break;
-	case 11:
-	  /*1011 0AAd dddd AAAA		IN Rd,A
-		1011 1AAd dddd AAAA		OUT A,Rd */ 
+
+	case 0x27U:
+		// 1001 11rd dddd rrrr		MUL Rd,Rr
+		Rd = r[D5];
+		Rr = r[R5];
+		uTmp = Rd * Rr; 
+		r0 = (u8)uTmp; 
+		r1 = (u8)(uTmp >> 8);
+		UPDATE_CZ_MUL(uTmp);
+		cycles=2;
+		break;
+
+	case 0x2CU: case 0x2DU:
+		// 1011 0AAd dddd AAAA		IN Rd,A
 		Rd = D5;
 		Rr = ((insn >> 5) & 0x30) | (insn & 0xF);
-		if (insn & 0x0800) // OUT
-		{
-			write_io(Rr,r[Rd]);
-		}
-		else	// IN
-		{
-			r[Rd] = read_io(Rr);
-		}
+		r[Rd] = read_io(Rr);
 		break;
-	case 12: /*1100 kkkk kkkk kkkk		RJMP k */
+
+	case 0x2EU: case 0x2FU:
+		// 1011 1AAd dddd AAAA		OUT A,Rd
+		Rd = D5;
+		Rr = ((insn >> 5) & 0x30) | (insn & 0xF);
+		write_io(Rr,r[Rd]);
+		break;
+
+	case 0x30U: case 0x31U: case 0x32U: case 0x33U:
+		// 1100 kkkk kkkk kkkk		RJMP k
 		pc += k12;
 		cycles=2;
 		break;
-	case 13: /*1101 kkkk kkkk kkkk		RCALL k */
+
+	case 0x34U: case 0x35U: case 0x36U: case 0x37U:
+		// 1101 kkkk kkkk kkkk		RCALL k
 		write_sram(SP,(u8)pc);
 		DEC_SP;
 		write_sram(SP,pc>>8);
@@ -1526,60 +1631,54 @@ u8 avr8::exec()
 		pc += k12;
 		cycles=3;
 		break;
-	case 14: /*1110 KKKK dddd KKKK		LDI Rd,K (SER is just LDI Rd,255) */
+
+	case 0x38U: case 0x39U: case 0x3AU: case 0x3BU:
+		// 1110 KKKK dddd KKKK		LDI Rd,K (SER is just LDI Rd,255)
 		r[D4 + 16] = K8;
 		break;
-	case 15:
-	  /*1111 00kk kkkk ksss		BRBS s,k (same here)
-		1111 01kk kkkk ksss		BRBC s,k (BRCC, etc are aliases for this with sss implicit)
-		1111 100d dddd 0bbb		BLD Rd,b
-		1111 101d dddd 0bbb		BST Rd,b
-		1111 110r rrrr 0bbb		SBRC Rr,b
-		1111 111r rrrr 0bbb		SBRS Rr,b */
-		switch ((insn >> 9) & 7)
+
+	case 0x3CU:
+		// 1111 00kk kkkk ksss		BRBS s,k (same here)
+		sTmp = k7;
+		if (SREG & (1<<(insn&7)))
 		{
-		case 0: case 1: /*BRBS*/
-			sTmp = k7;
-			if (SREG & (1<<(insn&7)))
-			{
-				pc += sTmp;
-				cycles=2;
-			}
-			break;
-		case 2: case 3: /*BRBC*/
-			sTmp = k7;
-			if (!(SREG & (1<<(insn&7))))
-			{
-				pc += sTmp;
-				cycles=2;
-			}
-			break;
-		case 4: /*BLD*/
+			pc += sTmp;
+			cycles=2;
+		}
+		break;
+
+	case 0x3DU:
+		// 1111 01kk kkkk ksss		BRBC s,k (BRCC, etc are aliases for this with sss implicit)
+		sTmp = k7;
+		if (!(SREG & (1<<(insn&7))))
+		{
+			pc += sTmp;
+			cycles=2;
+		}
+		break;
+
+	case 0x3EU:
+		// 1111 100d dddd 0bbb		BLD Rd,b
+		// 1111 101d dddd 0bbb		BST Rd,b
+		if ((insn & 0x0200U) == 0U)
+		{      // BLD
 			Rd = D5;
-			set_bit(r[Rd],insn&7,SREG & (1<<SREG_T));
-			break;
-		case 5: /*BST*/
+			set_bit_1(r[Rd],insn&7,(SREG >> SREG_T) & 1U);
+		}else{ // BST
 			Rd = r[D5];
-			set_bit(SREG,SREG_T,Rd & (1<<(insn&7)));
-			break;
-		case 6: /*SBRC*/
-			Rd = r[D5];
-			if (!(Rd & (1<<(insn&7))))
-			{
-				uTmp = get_insn_size(progmem[pc]);
-				cycles += uTmp;
-				pc += uTmp;
-			}
-			break;
-		case 7: /*SBRS*/
-			Rd = r[D5];
-			if (Rd & (1<<(insn&7)))
-			{
-				uTmp = get_insn_size(progmem[pc]);
-				cycles += uTmp;
-				pc += uTmp;
-			}
-			break;
+			set_bit_1(SREG,SREG_T,(Rd >> (insn&7)) & 1U);
+		}
+		break;
+
+	default:
+		// 1111 110r rrrr 0bbb		SBRC Rr,b
+		// 1111 111r rrrr 0bbb		SBRS Rr,b
+		Rd = r[D5];
+		if (((Rd >> (insn & 7U)) & 1U) == ((insn & 0x0200U) >> 9))
+		{
+			uTmp = get_insn_size(progmem[pc]);
+			cycles += uTmp;
+			pc += uTmp;
 		}
 		break;
 	}
@@ -1594,7 +1693,7 @@ void avr8::trigger_interrupt(int location)
 {
 
 		// clear interrupt flag
-		set_bit(SREG,SREG_I,0);
+		set_bit_1(SREG,SREG_I,0);
 
 		// push current PC
 		write_sram(SP,(u8)pc);

--- a/tools/uzem/avr8.h
+++ b/tools/uzem/avr8.h
@@ -328,7 +328,8 @@ struct avr8
 	u32 cycleCounter, prevPortB, prevWDR;
 	u32 watchdogTimer;
     u8 eeClock;
-	u8 T16_latch;				// for 16-bit timers
+	u8 T16_latch;             // Latch for 16-bit timers
+	unsigned int timer1_next; // Cycles remaining until next timer1 event
 	u16 TCNT1;
 	u8 tempTIFR1;
 	u16 OCR1A;

--- a/tools/uzem/avr8.h
+++ b/tools/uzem/avr8.h
@@ -498,6 +498,8 @@ struct avr8
 
 	void write_io(u8 addr,u8 value);
 	u8 read_io(u8 addr);
+	// Should not be called directly (see write_io)
+	void write_io_x(u8 addr,u8 value);
 
 	inline u8 read_progmem(u16 addr)
 	{
@@ -511,7 +513,7 @@ struct avr8
 		sram[(addr - SRAMBASE) & (sramSize - 1U)] = value;
 	}
 
-	inline void write_sram_io(u16 addr,u8 value)
+	void write_sram_io(u16 addr,u8 value)
 	{
 		if(addr>=SRAMBASE)
 		{
@@ -541,7 +543,7 @@ struct avr8
 		return sram[(addr - SRAMBASE) & (sramSize - 1U)];
 	}
 
-	inline u8 read_sram_io(u16 addr)
+	u8 read_sram_io(u16 addr)
 	{
 
 		if(addr>=SRAMBASE)

--- a/tools/uzem/avr_inst_table.txt
+++ b/tools/uzem/avr_inst_table.txt
@@ -1,0 +1,96 @@
+0000 0000 0000 0000		NOP
+0000 0001 dddd rrrr		MOVW Rd+1:Rd,Rr+1:R
+0000 0010 dddd rrrr		MULS Rd,Rr
+0000 0011 0ddd 0rrr		MULSU Rd,Rr (registers are in 16-23 range)
+0000 0011 0ddd 1rrr		FMUL Rd,Rr (registers are in 16-23 range)
+0000 0011 1ddd 0rrr		FMULS Rd,Rr
+0000 0011 1ddd 1rrr		FMULSU Rd,Rr
+0000 01rd dddd rrrr		CPC Rd,Rr
+0000 10rd dddd rrrr		SBC Rd,Rr
+0000 11rd dddd rrrr		ADD Rd,Rr (LSL is ADD Rd,Rd)
+0001 00rd dddd rrrr		CPSE Rd,Rr
+0001 01rd dddd rrrr		CP Rd,Rr
+0001 10rd dddd rrrr		SUB Rd,Rr
+0001 11rd dddd rrrr		ADC Rd,Rr (ROL is ADC Rd,Rd)
+0010 00rd dddd rrrr		AND Rd,Rr (TST is AND Rd,Rd)
+0010 01rd dddd rrrr		EOR Rd,Rr (CLR is EOR Rd,Rd)
+0010 10rd dddd rrrr		OR Rd,Rr
+0010 11rd dddd rrrr		MOV Rd,Rr
+0011 KKKK dddd KKKK		CPI Rd,K
+0100 KKKK dddd KKKK		SBCI Rd,K
+0101 KKKK dddd KKKK		SUBI Rd,K
+0110 KKKK dddd KKKK		ORI Rd,K (same as SBR insn)
+0111 KKKK dddd KKKK		ANDI Rd,K (CBR is ANDI with K complemented)
+10q0 qq0d dddd 0qqq		LD Rd,Z+q
+10q0 qq0d dddd 1qqq		LD Rd,Y+q
+10q0 qq1d dddd 0qqq		ST Z+q,Rd
+10q0 qq1d dddd 1qqq		ST Y+q,Rd
+1001 000d dddd 0000		LDS Rd,k (next word is rest of address)
+1001 000d dddd 0001		LD Rd,Z+
+1001 000d dddd 0010		LD Rd,-Z
+1001 000d dddd 0100		LPM Rd,Z
+1001 000d dddd 0101		LPM Rd,Z+
+1001 000d dddd 0110		ELPM Rd,Z
+1001 000d dddd 0111		ELPM Rd,Z+
+1001 000d dddd 1001		LD Rd,Y+
+1001 000d dddd 1010		LD Rd,-Y
+1001 000d dddd 1100		LD rd,X
+1001 000d dddd 1101		LD rd,X+
+1001 000d dddd 1110		LD rd,-X
+1001 000d dddd 1111		POP Rd
+1001 001d dddd 0000		STS k,Rr (next word is rest of address)
+1001 001r rrrr 0001		ST Z+,Rr
+1001 001r rrrr 0010		ST -Z,Rr
+1001 001r rrrr 1001		ST Y+,Rr
+1001 001r rrrr 1010		ST -Y,Rr
+1001 001r rrrr 1100		ST X,Rr
+1001 001r rrrr 1101		ST X+,Rr
+1001 001r rrrr 1110		ST -X,Rr
+1001 001d dddd 1111		PUSH Rd
+1001 010d dddd 0000		COM Rd
+1001 010d dddd 0001		NEG Rd
+1001 010d dddd 0010		SWAP Rd
+1001 010d dddd 0011		INC Rd
+1001 010d dddd 0101		ASR Rd
+1001 010d dddd 0110		LSR Rd
+1001 010d dddd 0111		ROR Rd
+1001 010d dddd 1010		DEC Rd
+1001 010k kkkk 110k		JMP k (next word is rest of address)
+1001 010k kkkk 111k		CALL k (next word is rest of address)
+1001 0100 0sss 1000		BSET s (SEC, etc are aliases with sss implicit)
+1001 0100 1sss 1000		BCLR s (CLC, etc are aliases with sss implicit)
+1001 0100 0000 1001		IJMP (jump thru Z register)
+1001 0100 0001 1001		EIJMP (probably not on 644)
+1001 0100 KKKK 1011		DES (probably not on 644)
+1001 0101 0000 1000		RET
+1001 0101 0000 1001		ICALL (call thru Z register)
+1001 0101 0001 1000		RETI
+1001 0101 0001 1001		EICALL (probably not on 644)
+1001 0101 1000 1000		SLEEP
+1001 0101 1001 1000		BREAK
+1001 0101 1010 1000		WDR
+1001 0101 1100 1000		LPM (r0 implied, why is this special?)
+1001 0101 1101 1000		ELPM (r0 implied)
+1001 0101 1110 1000		SPM Z (writes R1:R0)
+1001 0110 KKdd KKKK		ADIW Rd+1:Rd,K   (16-bit add to upper four register pairs)
+1001 0111 KKdd KKKK		SBIW Rd+1:Rd,K
+1001 1000 AAAA Abbb		CBI A,b
+1001 1001 AAAA Abbb		SBIC A,b
+1001 1010 AAAA Abbb		SBI A,b
+1001 1011 AAAA Abbb		SBIS A,b
+1001 11rd dddd rrrr		MUL Rd,Rr
+1011 0AAd dddd AAAA		IN Rd,A
+1011 1AAd dddd AAAA		OUT A,Rd
+1100 kkkk kkkk kkkk		RJMP k
+1101 kkkk kkkk kkkk		RCALL k
+1110 KKKK dddd KKKK		LDI Rd,K (SER is just LDI Rd,255)
+1111 00kk kkkk ksss		BRBS s,k (same here)
+1111 01kk kkkk ksss		BRBC s,k (BRCC, etc are aliases for this with sss implicit)
+1111 100d dddd 0bbb		BLD Rd,b
+1111 101d dddd 0bbb		BST Rd,b
+1111 110r rrrr 0bbb		SBRC Rr,b
+1111 111r rrrr 0bbb		SBRS Rr,b
+
+
+
+


### PR DESCRIPTION
The quest for performance as completed.

I tried to be descriptive in my commit messages, so hopefully they can be followed. There are many changes in here, looks more than really, mostly due to the instruction decoder's rearrangement. I mostly didn't touch the actual instruction codes, only as necessary to integrate them. The change of the flag logic resulted the most notable intrusion, that every instruction operating the flags now has a call to a clear macro.

Comments were also added describing components of the code, also including some TODO notes where I discovered problems with the original code. Most notably there might be timing issues regarding interrupts even in the original, which might expose with AVR code relying on certain edge cases. I didn't attempt to fix these (since I don't know how the real thing is supposed to behave), leaving the way it was. Once these are figured out, some minor clean-ups and maybe performance boost might still be achieved by a proper generic implementation of the problem.