### PR TITLE
Add (optional) Emscripten support by setting a flag in the Makefile

### DIFF
--- a/tools/uzem/Makefile
+++ b/tools/uzem/Makefile
@@ -13,6 +13,14 @@
 
 TARGETS = debug release
 
+#Uncomment to build Emscripten version (and be sure to add `arguments: ["gamefile.uze"],` below `var Module = {` in generated uzem.html file)
+#EMSCRIPTEN_BUILD=1
+
+ifeq ($(EMSCRIPTEN_BUILD),1)
+    EMSCRIPTEN_FLAGS=-O3 -s USE_SDL=2 -s AGGRESSIVE_VARIABLE_ELIMINATION=1 --llvm-lto 1
+    EMSCRIPTEN_TARGET_EXTRAS=.html --preload-file gamefile.uze --preload-file eeprom.bin
+endif
+
 #Uncomment to optimize for local CPU
 #ARCH=native
 #TUNE=y
@@ -50,7 +58,7 @@ CPPFLAGS += $(SDL_FLAGS) -D$(OS) -D_GNU_SOURCE=1 -DGUI=1 -DJOY_ANALOG_DEADZONE=8
 ######################################
 RELEASE_NAME = uzem$(OS_EXTENSION)
 RELEASE_OBJ_DIR := Release
-RELEASE_CPPFLAGS = $(CPPFLAGS) -O3 
+RELEASE_CPPFLAGS = $(CPPFLAGS) -O3 $(EMSCRIPTEN_FLAGS)
 
 ######################################
 # Debug definitions
@@ -58,7 +66,7 @@ RELEASE_CPPFLAGS = $(CPPFLAGS) -O3
 DEBUG_NAME = uzemdbg$(OS_EXTENSION)
 DEBUG_OBJ_DIR := Debug
 DEBUG_DEFINES := USE_SPI_DEBUG=1 USE_EEPROM_DEBUG=1 USE_GDBSERVER_DEBUG=1
-DEBUG_CPPFLAGS = $(CPPFLAGS) -g
+DEBUG_CPPFLAGS = $(CPPFLAGS) -g $(EMSCRIPTEN_FLAGS)
 
 ######################################
 # SD Options
@@ -78,9 +86,15 @@ PLATFORM = Unknown
 ifeq ($(UNAME),Linux)
 OS := LINUX
 PLATFORM := Unix
-SDL_FLAGS := $(shell sdl2-config --cflags)
-LDFLAGS += $(shell sdl2-config --libs)
-CC := g++
+ifeq ($(EMSCRIPTEN_BUILD),1)
+    SDL_FLAGS :=
+    LDFLAGS += $(EMSCRIPTEN_FLAGS)
+    CC := emcc
+else
+    SDL_FLAGS := $(shell sdl2-config --cflags)
+    LDFLAGS += $(shell sdl2-config --libs)
+    CC := g++
+endif
 MKDIR := mkdir -p
 RM := rm -rf
 MTOOLS = 
@@ -199,7 +213,7 @@ $(TARGETS): msg $(TARGET_NAME)
 	@echo done!
 
 $(TARGET_NAME): $(TARGET_OBJS) $(SDL_DLL)
-	$(CC) $(TARGET_OBJS) -o $(TARGET_NAME) $(CPPFLAGS) $(LDFLAGS) $(TARGET_D_DEFINES)
+	$(CC) $(TARGET_OBJS) -o $(TARGET_NAME)$(EMSCRIPTEN_TARGET_EXTRAS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_D_DEFINES)
 
 $(TARGET_OBJ_DIR)/%.o: %.cpp
 	$(CC) -c $< -o $@ $(TARGET_CPPFLAGS) $(DEPFLAGS) $(TARGET_D_DEFINES)

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -305,7 +305,9 @@ void avr8::write_io_x(u8 addr,u8 value)
 		if (enableSound && TCCR2B)
 		{
 			// raw pcm sample at 15.7khz
+#ifndef __EMSCRIPTEN__
 			while (audioRing.isFull())SDL_Delay(1);
+#endif
 			SDL_LockAudio();
 			audioRing.push(value);
 			SDL_UnlockAudio();

--- a/tools/uzem/uzem.cpp
+++ b/tools/uzem/uzem.cpp
@@ -408,7 +408,7 @@ int main(int argc,char **argv)
 	uzebox.cycleCounter=-1;
 
 #ifdef __EMSCRIPTEN__
-	emscripten_set_main_loop(one_iter, 0, 1);
+	emscripten_set_main_loop(one_iter, 60, 1);
 	emscripten_set_main_loop_timing(EM_TIMING_RAF, 1);
 #else
 	while (true)


### PR DESCRIPTION
I found out how to pass arguments to an Emscripten build from the generated .html file, so the changes required to support compiling with Emscripten ended up being pretty minimal, so I conditionalized them in both the code and in the Makefile

If the EMSCRIPTEN_BUILD line is commented out in the Makefile (which it is by default) then the other EMSCRIPTEN_* variables will default to nothing, so it won't actually change the behavior of the non-Emscripten builds, even those variables appear in various other places. (The places where I put spaces, and the places where I didn't put spaces was intentional and is required, so please don't change any of the spacing.)

I figured that this was the least invasive approach, since it still allows for a debug and release version of the Emscripten builds to be created. It assumes a Linux Emscripten environment, because that's the only one that builds itself from source, which is desirable because the Linux version will automatically download and compile any of the dependencies that the Emscripten version needs to compile.