### PR TITLE
Fix all warnings except the sign comparison ones. (Allows web-based Uzem to play ROMs that use SD card)

### DIFF
--- a/tools/uzem/SDEmulator.cpp
+++ b/tools/uzem/SDEmulator.cpp
@@ -114,7 +114,7 @@ int SDEmu::init_with_directory(const char *path) {
 	int freecluster = 2;
 	printf("SD Emulation of following files:\n");
 	while ((entry = readdir(dir))) {
-		if (entry->d_name && entry->d_name[0] != '.') {
+		if (entry && entry->d_name[0] != '.') {
 			char *statpath = (char *)malloc(strlen(path) + strlen(entry->d_name) + 2);
 			strcpy(statpath, path);
 			strcat(statpath, "/");

--- a/tools/uzem/SDEmulator.cpp
+++ b/tools/uzem/SDEmulator.cpp
@@ -136,7 +136,7 @@ int SDEmu::init_with_directory(const char *path) {
 			clusters[freecluster+fileClustersCount-1]=0xffff; //Last cluster in file marker (EOC)
 
 			toc[i].filesize = st.st_size;
-			printf("\t%d: %s:%d\n", i, entry->d_name, st.st_size, toc[i].cluster_no);
+			printf("\t%d: %s:%ld\n", i, entry->d_name, st.st_size);
 			freecluster += fileClustersCount;
 			if (++i == MAX_FILES) {
 				break;
@@ -146,7 +146,7 @@ int SDEmu::init_with_directory(const char *path) {
 	return 0;
 }
 
-int SDEmu::read(unsigned char *ptr) {
+void SDEmu::read(unsigned char *ptr) {
 	static int lastfile=-1;
 	static int lastfileStart=0;
 	static int lastfileEnd=0;
@@ -221,6 +221,6 @@ int SDEmu::read(unsigned char *ptr) {
 
 }
 
-int SDEmu::seek(int pos) {
+void SDEmu::seek(int pos) {
 	position = pos;
 }

--- a/tools/uzem/SDEmulator.h
+++ b/tools/uzem/SDEmulator.h
@@ -143,8 +143,8 @@ struct SDEmu
 	int position;
 
 	int init_with_directory(const char *path);
-	int read(unsigned char *ptr);
-	int seek(int pos);
+	void read(unsigned char *ptr);
+	void seek(int pos);
 	void debug(bool value);
 };
 

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -2818,6 +2818,7 @@ u8 avr8::SDReadByte(){
 }
 
 void avr8::SDWriteByte(u8 value){    
+    (void)value;
     fprintf(stderr, "No write support in SD emulation\n");
 }
 
@@ -2855,7 +2856,7 @@ void avr8::LoadEEPROMFile(const char* filename){
 
 		size_t result=fread(eeprom,1,size,f);
         if (result != size){
-        	printf("Warning: fread in %s returned an unexpected value:%i,\n", __FUNCTION__,result);
+        	printf("Warning: fread in %s returned an unexpected value:%lu,\n", __FUNCTION__,result);
         }
         fclose(f);
     }

--- a/tools/uzem/gdbserver.cpp
+++ b/tools/uzem/gdbserver.cpp
@@ -181,9 +181,9 @@ void GdbServer::avr_core_insert_breakpoint(dword pc) {
     BP.push_back(pc);
 }
 
-int GdbServer::signal_has_occurred(int signo) {return 0;}
-void GdbServer::signal_watch_start(int signo){};
-void GdbServer::signal_watch_stop(int signo){};
+int GdbServer::signal_has_occurred(int signo) {(void)signo; return 0;}
+void GdbServer::signal_watch_start(int signo){(void)signo;}
+void GdbServer::signal_watch_stop(int signo){(void)signo;}
 
 
 static char HEX_DIGIT[] = "0123456789abcdef";
@@ -268,7 +268,7 @@ void GdbServer::gdb_write( const void *buf, size_t count )
     unsent bytes. */
 
     if ((unsigned int)res != count)
-        printf( "write only wrote %d of %d bytes", res, count );
+        printf( "write only wrote %d of %ld bytes", res, count );
 }
 
 /* Use a single function for storing/getting the last reply message.

--- a/tools/uzem/gdbserver.h
+++ b/tools/uzem/gdbserver.h
@@ -52,7 +52,7 @@
 
 using namespace std;
 
-class avr8;
+struct avr8;
 
 typedef uint8_t byte;
 typedef uint16_t word;

--- a/tools/uzem/uzem.cpp
+++ b/tools/uzem/uzem.cpp
@@ -266,7 +266,7 @@ int main(int argc,char **argv)
 
     	//build the capture file name
 		int len=strlen(uzebox.romName);
-		char capfname[len+4];
+		char capfname[len+5];
 		strcpy(capfname,uzebox.romName);
 		capfname[len+0]='.';
 		capfname[len+1]='c';

--- a/tools/uzem/uzem.cpp
+++ b/tools/uzem/uzem.cpp
@@ -183,7 +183,7 @@ int main(int argc,char **argv)
     // get leftovers
     for (int i = optind; i < argc; ++i) {
         if(heximage){
-            printerr("Error: HEX file already specified (too many arguments?).\n\n",heximage);
+            printerr("Error: HEX file already specified (too many arguments?).\n\n");
             showHelp(argv[0]);
             return 1;
         }
@@ -193,7 +193,7 @@ int main(int argc,char **argv)
     }
     
     if (uzebox.gdbPort == 0) {
-        printerr("Error: invalid port address.\n\n",uzebox.gdbPort);
+        printerr("Error: invalid port address.\n\n");
         showHelp(argv[0]);
         return 1;
     }

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -118,7 +118,7 @@ static int parse_hex_word(const char *s)
 
 bool loadHex(const char *in_filename,unsigned char *buffer,unsigned int *bytesRead)
 {
-	
+	(void)bytesRead;
 	//http://en.wikipedia.org/wiki/.hex
 
 	//(I've added the spaces for clarity, they don't exist in the real files)


### PR DESCRIPTION
This allows Uzem to be properly built using clang++ rather than g++,
which allow games that use the SD card to run properly when built for
the web using Emscripten.