### PR TITLE
Add "used" attribute to wdt_init and Initialize

### DIFF
--- a/kernel/uzeboxCore.c
+++ b/kernel/uzeboxCore.c
@@ -76,8 +76,8 @@ const u8 eeprom_format_table[] PROGMEM ={(u8)EEPROM_SIGNATURE,		//(u16)
 
 extern void wdt_randomize(void);
 
-void wdt_init(void) __attribute__((naked)) __attribute__((section(".init7")));
-void Initialize(void) __attribute__((naked)) __attribute__((section(".init8")));
+void wdt_init(void) __attribute__((naked)) __attribute__((section(".init7"), used));
+void Initialize(void) __attribute__((naked)) __attribute__((section(".init8"), used));
 
 void wdt_init(void)
 {


### PR DESCRIPTION
This prevents the compiler/linker from removing the necessary .init7
and .init8 sections when compiling games that have:

COMMON = -mmcu=$(MCU) -flto -fwhole-program

in their Makefile.

Without the "used" attribute, the linker will remove those sections,
breaking the game.