### PR TITLE
Make ends_with function case insensitiv, therefore it doesn't matter …

### DIFF
--- a/tools/uzem/uzem.cpp
+++ b/tools/uzem/uzem.cpp
@@ -100,7 +100,7 @@ int ends_with(const char* name, const char* extension, size_t length)
  {
    if (length == 0)
 	 length = strlen(extension);
-   return strncmp(ldot + 1, extension, length) == 0;
+   return strncasecmp(ldot + 1, extension, length) == 0;
  }
  return 0;
 }
@@ -241,8 +241,7 @@ int main(int argc,char **argv)
 
     	unsigned char* buffer = (unsigned char*)(uzebox.progmem);
 
-	// Converting to lowercase on case sensitive file systems causes not found errors, so check for both here
-    	if(ends_with(heximage,"uze", 3) || ends_with(heximage,"UZE", 3)){
+    	if(ends_with(heximage,"uze", 3)){
 
 
         	if(isUzeromFile(heximage)){


### PR DESCRIPTION
…if files are ending with .uze, .UZE, uZe or whatever.