### PR TITLE
Bugfix: Added include for stdint.h to kernel/sdBase.h

### DIFF
--- a/kernel/sdBase.h
+++ b/kernel/sdBase.h
@@ -21,6 +21,8 @@
 */
 #pragma once
 
+#include <stdint.h>
+
 #ifdef SD_CARD_DEBUG
     extern uint32_t SD_DEBUG_bootRecordSector;
     extern uint16_t SD_DEBUG_bytesPerSector;


### PR DESCRIPTION
This fixes compiling errors which occur if sdBase.h is included before an
other include which provides stdint.h whose types it uses.