### PR TITLE
gconvert: Tile defines

### DIFF
--- a/tools/gconvert/gconvert.cpp
+++ b/tools/gconvert/gconvert.cpp
@@ -55,6 +55,12 @@ struct TileMap {
 	int height;
 };
 
+struct TileDefine {
+	const char* defName;
+	int left;
+	int top;
+};
+
 struct Palette {
 	unsigned char colors[256];
 	int numColors;
@@ -87,7 +93,10 @@ struct ConvertionDefinition {
 	int mapsPointersSize;
 	TileMap* maps;
 	int mapsCount;
-	
+
+	TileDefine* defines;
+	int definesCount;
+
 	Palette palette;
 };
 
@@ -313,7 +322,42 @@ bool process(){
 		}
 	}
 
-	//Export maps first
+	//Export tile defines first
+	if(xform.defines!=NULL){
+		for(int d=0; d<xform.definesCount; d++){
+			TileDefine def=xform.defines[d];
+
+			//validate tile define
+			if (def.defName==NULL) {
+				printf("Error: def-name not set for tile define\n");
+				return false;
+			}
+			else if(def.left>=horizontalTiles || def.top>=verticalTiles){
+				printf("Error: Position is are out of bound for tile define: %s\n",def.defName);
+				return false;
+			}
+
+			int index = -1;
+			unsigned char* tile=getTileAt(def.left,def.top,&image);
+			for(unsigned int i=0;i<uniqueTiles.size();i++){
+				unsigned char* b=uniqueTiles.at(i);
+				if(tilesEqual(tile,b,image.tileWidth*image.tileHeight)){
+					index=i;	//tile found in tile list
+					break;
+				}
+			}
+			free(tile);
+
+			if(index==-1){
+				printf("Define tile not found in tileset!\n");
+				return false;
+			}
+
+			fprintf(tf,"#define %s %i\n", toUpperCase(def.defName), index);
+		}
+	}
+
+	//Export maps second
 	if(xform.maps!=NULL){
 
 		int index=0;
@@ -902,6 +946,32 @@ void parseXml(TiXmlDocument* doc){
 		xform.maps=NULL;
 	}
 
+	//tile defines
+	TiXmlElement* definesElem=output->FirstChildElement("defines");
+	if(definesElem!=NULL){
+		//count # of define sub-elements
+		const TiXmlNode* node;
+		int defineCount=0;
+		for(node=definesElem->FirstChild("define");node;node=node->NextSibling("define"))defineCount++;
+
+		TileDefine* defines=new TileDefine[defineCount];
+		xform.definesCount=defineCount;
+		defineCount=0;
+		for(node=definesElem->FirstChild("define");node;node=node->NextSibling("define")){
+			defines[defineCount].defName=node->ToElement()->Attribute("def-name");
+
+			node->ToElement()->QueryIntAttribute("top",&defines[defineCount].top);
+			node->ToElement()->QueryIntAttribute("left",&defines[defineCount].left);
+			defineCount++;
+		}
+		if(defineCount>0){
+			xform.defines=defines;
+		}else{
+			xform.defines=NULL;
+		}
+	}else{
+		xform.defines=NULL;
+	}
 }
 
 //load image in a byte arrays


### PR DESCRIPTION
It works similar to maps.
For example, adding this section to the xml:
```
<defines>
<define def-name="SKY_TILE" left="0" top="10"/>
<define def-name="ARROW_TILE" left="10" top="0"/>
<define def-name="PAINTED_TILE" left="11" top="0"/>
<define def-name="PERIOD_TILE" left="14" top="0"/>
<define def-name="HIT_TILE" left="3" top="10"/>
<define def-name="NON_FIRE_TILE" left="1" top="11"/>
<define def-name="FIRE_TILE" left="2" top="11"/>
<define def-name="CRACK_TILE" left="3" top="11"/>
<define def-name="T_TILE" left="0" top="13"/>
<define def-name="B_TILE" left="1" top="13"/>
<define def-name="L_TILE" left="2" top="13"/>
<define def-name="R_TILE" left="3" top="13"/>
<define def-name="TL_TILE" left="4" top="13"/>
<define def-name="BL_TILE" left="5" top="13"/>
<define def-name="BR_TILE" left="6" top="13"/>
<define def-name="TR_TILE" left="7" top="13"/>
<define def-name="NO_TILE" left="8" top="13"/>
<define def-name="ABOUT_TILE" left="2" top="20"/>
<define def-name="CAT_TILE" left="0" top="21"/>
<define def-name="RED_BALL_TILE" left="1" top="21"/>
<define def-name="GREEN_BALL_TILE" left="2" top="21"/>
<define def-name="BLOCK_TILE" left="0" top="22"/>
<define def-name="BLOODY_BLOCK_TILE" left="1" top="22"/>
</defines>
```

Will result in:
```
#define SKY_TILE 187
#define ARROW_TILE 10
#define PAINTED_TILE 11
#define PERIOD_TILE 14
#define HIT_TILE 189
#define NON_FIRE_TILE 190
#define FIRE_TILE 191
#define CRACK_TILE 192
#define T_TILE 193
#define B_TILE 194
#define L_TILE 195
#define R_TILE 196
#define TL_TILE 197
#define BL_TILE 198
#define BR_TILE 199
#define TR_TILE 200
#define NO_TILE 201
#define ABOUT_TILE 240
#define CAT_TILE 241
#define RED_BALL_TILE 242
#define GREEN_BALL_TILE 243
#define BLOCK_TILE 244
#define BLOODY_BLOCK_TILE 244
```