### PR TITLE
Properly allocate bytes in the bss

### DIFF
--- a/demos/Bootloader/bootloaderCore.s
+++ b/demos/Bootloader/bootloaderCore.s
@@ -138,23 +138,23 @@
 	fontram:	.space FONT_SIZE*8 ;unpacked size
 
 
-	sync_phase:  .byte 1 ;0=pre-eq, 1=eq, 2=post-eq, 3=hsync, 4=vsync
-	sync_pulse:	 .byte 1
-	vsync_flag:	 .byte 1	;set 30 hz
-	curr_field:	 .byte 1	;0 or 1, changes at 60hz
+	sync_phase:  .space 1 ;0=pre-eq, 1=eq, 2=post-eq, 3=hsync, 4=vsync
+	sync_pulse:	 .space 1
+	vsync_flag:	 .space 1	;set 30 hz
+	curr_field:	 .space 1	;0 or 1, changes at 60hz
 
-	first_render_line:	.byte 1
-	screen_tiles_v: 	.byte 1
+	first_render_line:	.space 1
+	screen_tiles_v: 	.space 1
 
-	first_render_line_tmp:	.byte 1
-	screen_tiles_v_tmp: 	.byte 1
+	first_render_line_tmp:	.space 1
+	screen_tiles_v_tmp: 	.space 1
 
 	;last read results of joypads	
-	joypad_status:		.word 1
+	joypad_status:		.space 2
 
-	wave_pos:		.byte 1
-	wave_vol:		.byte 1
-	wave_vol_frac:	.byte 1
+	wave_pos:		.space 1
+	wave_vol:		.space 1
+	wave_vol_frac:	.space 1
 
 .section .init8
 	call InitVideo

--- a/demos/Bootloader/mmc.s
+++ b/demos/Bootloader/mmc.s
@@ -40,7 +40,7 @@
 
 
 .section .bss
-	sector_buffer_ptr:	.word 1  ;pointer to sector buffer (at least 512 bytes)
+	sector_buffer_ptr:	.space 2  ;pointer to sector buffer (at least 512 bytes)
 	last_sector:		.space 4 ;used for caching
 
 .section .text

--- a/demos/Megatris/asmFunctions.s
+++ b/demos/Megatris/asmFunctions.s
@@ -30,8 +30,8 @@
 .global RestoreTile
 
 .section .bss
-	tile_map_lo:	.byte 1
-	tile_map_hi:	.byte 1
+	tile_map_lo:	.space 1
+	tile_map_hi:	.space 1
 
 ;*****************************
 ; Defines a tile map

--- a/demos/tutorialSD/mmc.s
+++ b/demos/tutorialSD/mmc.s
@@ -32,7 +32,7 @@
 #define SD_DATA_TOKEN 0xFE
 
 .section .bss
-    sd_512_byte_count:     .word 1
+    sd_512_byte_count:     .space 2
 
 .global sdDirectRead
 .global sdFindFileFirstSector

--- a/kernel/mmc.s
+++ b/kernel/mmc.s
@@ -42,7 +42,7 @@
 
 
 .section .bss
-	sector_buffer_ptr:	.word 1  ;pointer to sector buffer (at least 512 bytes)
+	sector_buffer_ptr:	.space 2  ;pointer to sector buffer (at least 512 bytes)
 	last_sector:		.space 4 ;used for caching
 
 .section .text

--- a/kernel/sdBase.S
+++ b/kernel/sdBase.S
@@ -32,7 +32,7 @@
 #define SD_DATA_TOKEN 0xFE
 
 .section .bss
-    sd_512_byte_count:     .word 1        ; Counter for sector reading.  After every 512 bytes read from SD card
+    sd_512_byte_count:     .space 2        ; Counter for sector reading.  After every 512 bytes read from SD card
                                           ; in READ_MULTIPLE_BLOCK mode there are several non-data bytes.  These
                                           ; comprise of two CRC bytes, 0 or more stuff bytes and a data ready token
 
@@ -48,15 +48,15 @@
     .global SD_DEBUG_firstSector
 
     .section .bss
-        SD_DEBUG_bootRecordSector:        .long 1
-        SD_DEBUG_bytesPerSector:          .word 1
-        SD_DEBUG_sectorsPerCluster:       .byte 1
-        SD_DEBUG_reservedSectors:         .word 1
-        SD_DEBUG_maxRootDirectoryEntries: .word 1
-        SD_DEBUG_sectorsPerFat:           .word 1
-        SD_DEBUG_dirTableSector:          .long 1
-        SD_DEBUG_firstCluster:            .word 1
-        SD_DEBUG_firstSector:             .long 1
+        SD_DEBUG_bootRecordSector:        .space 4
+        SD_DEBUG_bytesPerSector:          .space 2
+        SD_DEBUG_sectorsPerCluster:       .space 1
+        SD_DEBUG_reservedSectors:         .space 2
+        SD_DEBUG_maxRootDirectoryEntries: .space 2
+        SD_DEBUG_sectorsPerFat:           .space 2
+        SD_DEBUG_dirTableSector:          .space 4
+        SD_DEBUG_firstCluster:            .space 2
+        SD_DEBUG_firstSector:             .space 4
 #endif
 
 

--- a/kernel/soundMixerInline.s
+++ b/kernel/soundMixerInline.s
@@ -57,53 +57,53 @@
 
 .section .bss
 
-	sound_enabled:.byte 1
+	sound_enabled:.space 1
 
 	//struct MixerStruct -> soundEngine.h
-	mixer:	
+	mixer:
 	mixerStruct:
 
-	tr1_vol:		 .byte 1
-	tr1_step_lo:	 .byte 1
-	tr1_step_hi:	 .byte 1
-	tr1_pos_frac:	 .byte 1
-	tr1_pos_lo:		 .byte 1
-	tr1_pos_hi:		 .byte 1
+	tr1_vol:		 .space 1
+	tr1_step_lo:	 .space 1
+	tr1_step_hi:	 .space 1
+	tr1_pos_frac:	 .space 1
+	tr1_pos_lo:		 .space 1
+	tr1_pos_hi:		 .space 1
 
-	tr2_vol:		 .byte 1
-	tr2_step_lo:	 .byte 1
-	tr2_step_hi:	 .byte 1
-	tr2_pos_frac:	 .byte 1
-	tr2_pos_lo:		 .byte 1
-	tr2_pos_hi:		 .byte 1
+	tr2_vol:		 .space 1
+	tr2_step_lo:	 .space 1
+	tr2_step_hi:	 .space 1
+	tr2_pos_frac:	 .space 1
+	tr2_pos_lo:		 .space 1
+	tr2_pos_hi:		 .space 1
 
-	tr3_vol:		 .byte 1
-	tr3_step_lo:	 .byte 1
-	tr3_step_hi:	 .byte 1
-	tr3_pos_frac:	 .byte 1
-	tr3_pos_lo:		 .byte 1
-	tr3_pos_hi:		 .byte 1
+	tr3_vol:		 .space 1
+	tr3_step_lo:	 .space 1
+	tr3_step_hi:	 .space 1
+	tr3_pos_frac:	 .space 1
+	tr3_pos_lo:		 .space 1
+	tr3_pos_hi:		 .space 1
 
-	tr4_vol:		 .byte 1
-	tr4_params:		 .byte 1 //bit0=>0=7,1=15 bits lfsr, b1:6=divider 
-	tr4_barrel_lo:	 .byte 1
-	tr4_barrel_hi:	 .byte 1
-	tr4_divider:	 .byte 1 ;current divider accumulator
-	tr4_reserved1:	 .byte 1
+	tr4_vol:		 .space 1
+	tr4_params:		 .space 1 //bit0=>0=7,1=15 bits lfsr, b1:6=divider 
+	tr4_barrel_lo:	 .space 1
+	tr4_barrel_hi:	 .space 1
+	tr4_divider:	 .space 1 ;current divider accumulator
+	tr4_reserved1:	 .space 1
 
 #if SOUND_CHANNEL_5_ENABLE==1
-	tr5_vol:		 .byte 1
-	tr5_step_lo:	 .byte 1
-	tr5_step_hi:	 .byte 1
-	tr5_pos_frac:	 .byte 1
-	tr5_pos_lo:		 .byte 1
-	tr5_pos_hi:		 .byte 1
-;	tr5_loop_start_lo: .byte 1
-;	tr5_loop_start_hi: .byte 1
-	tr5_loop_len_lo: .byte 1
-	tr5_loop_len_hi: .byte 1
-	tr5_loop_end_lo: .byte 1
-	tr5_loop_end_hi: .byte 1
+	tr5_vol:		 .space 1
+	tr5_step_lo:	 .space 1
+	tr5_step_hi:	 .space 1
+	tr5_pos_frac:	 .space 1
+	tr5_pos_lo:		 .space 1
+	tr5_pos_hi:		 .space 1
+;	tr5_loop_start_lo: .space 1
+;	tr5_loop_start_hi: .space 1
+	tr5_loop_len_lo: .space 1
+	tr5_loop_len_hi: .space 1
+	tr5_loop_end_lo: .space 1
+	tr5_loop_end_hi: .space 1
 #endif
 
 .section .text

--- a/kernel/soundMixerVsync.s
+++ b/kernel/soundMixerVsync.s
@@ -61,58 +61,58 @@
 
 
 mix_buf: 	  .space MIX_BUF_SIZE
-mix_pos:	  .word 1
-mix_bank: 	  .byte 1 ;0=first half,1=second half
-mix_block:	  .byte 1
+mix_pos:	  .space 2
+mix_bank: 	  .space 1 ;0=first half,1=second half
+mix_block:	  .space 1
 
-sound_enabled:.byte 1
+sound_enabled:.space 1
 
 //struct MixerStruct -> soundEngine.h
-mixer:	
+mixer:
 mixerStruct:
 
 
-tr1_vol:		 .byte 1
-tr1_step_lo:	 .byte 1
-tr1_step_hi:	 .byte 1
-tr1_pos_frac:	 .byte 1
-tr1_pos_lo:		 .byte 1
-tr1_pos_hi:		 .byte 1
+tr1_vol:		 .space 1
+tr1_step_lo:	 .space 1
+tr1_step_hi:	 .space 1
+tr1_pos_frac:	 .space 1
+tr1_pos_lo:		 .space 1
+tr1_pos_hi:		 .space 1
 
-tr2_vol:		 .byte 1
-tr2_step_lo:	 .byte 1
-tr2_step_hi:	 .byte 1
-tr2_pos_frac:	 .byte 1
-tr2_pos_lo:		 .byte 1
-tr2_pos_hi:		 .byte 1
+tr2_vol:		 .space 1
+tr2_step_lo:	 .space 1
+tr2_step_hi:	 .space 1
+tr2_pos_frac:	 .space 1
+tr2_pos_lo:		 .space 1
+tr2_pos_hi:		 .space 1
 
-tr3_vol:		 .byte 1
-tr3_step_lo:	 .byte 1
-tr3_step_hi:	 .byte 1
-tr3_pos_frac:	 .byte 1
-tr3_pos_lo:		 .byte 1
-tr3_pos_hi:		 .byte 1
+tr3_vol:		 .space 1
+tr3_step_lo:	 .space 1
+tr3_step_hi:	 .space 1
+tr3_pos_frac:	 .space 1
+tr3_pos_lo:		 .space 1
+tr3_pos_hi:		 .space 1
 
 
 #if MIXER_CHAN4_TYPE == 0
-	tr4_vol:		 .byte 1
-	tr4_params:		 .byte 1 //bit0=>0=7,1=15 bits lfsr, b1:6=divider 
-	tr4_barrel_lo:	 .byte 1
-	tr4_barrel_hi:	 .byte 1
-	tr4_divider:	 .byte 1 ;current divider accumulator
-	tr4_reserved1:	 .byte 1
+	tr4_vol:		 .space 1
+	tr4_params:		 .space 1 //bit0=>0=7,1=15 bits lfsr, b1:6=divider
+	tr4_barrel_lo:	 .space 1
+	tr4_barrel_hi:	 .space 1
+	tr4_divider:	 .space 1 ;current divider accumulator
+	tr4_reserved1:	 .space 1
 
 #else
-	tr4_vol:		 .byte 1
-	tr4_step_lo:	 .byte 1
-	tr4_step_hi:	 .byte 1
-	tr4_pos_frac:	 .byte 1
-	tr4_pos_lo:		 .byte 1
-	tr4_pos_hi:		 .byte 1
-	tr4_loop_len_lo: .byte 1
-	tr4_loop_len_hi: .byte 1
-	tr4_loop_end_lo: .byte 1
-	tr4_loop_end_hi: .byte 1
+	tr4_vol:		 .space 1
+	tr4_step_lo:	 .space 1
+	tr4_step_hi:	 .space 1
+	tr4_pos_frac:	 .space 1
+	tr4_pos_lo:		 .space 1
+	tr4_pos_hi:		 .space 1
+	tr4_loop_len_lo: .space 1
+	tr4_loop_len_hi: .space 1
+	tr4_loop_end_lo: .space 1
+	tr4_loop_end_hi: .space 1
 
 #endif
 

--- a/kernel/uzeboxVideoEngineCore.s
+++ b/kernel/uzeboxVideoEngineCore.s
@@ -97,33 +97,33 @@
 .section .bss
 	.align 1
 
-	sync_phase:  .byte 1	;0=vsync, 1=hsync
-	sync_pulse:	 .byte 1	;scanline counter
-	sync_flags:  .byte 1	;b0: vsync flag, set at 60Hz when video frame rendered
+	sync_phase:  .space 1	;0=vsync, 1=hsync
+	sync_pulse:	 .space 1	;scanline counter
+	sync_flags:  .space 1	;b0: vsync flag, set at 60Hz when video frame rendered
 							;b1: current field (0=odd, 1=even)
 
-	pre_vsync_user_callback:  .word 1 ;pointer to function
-	post_vsync_user_callback: .word 1 ;pointer to function
+	pre_vsync_user_callback:  .space 2 ;pointer to function
+	post_vsync_user_callback: .space 2 ;pointer to function
 
-	first_render_line:		.byte 1
-	render_lines_count: 	.byte 1
+	first_render_line:		.space 1
+	render_lines_count: 	.space 1
 
 	
 	;last read results of joypads
-	joypad1_status_lo:	.byte 1
-						.byte 1
-	joypad1_status_hi:	.byte 1
-						.byte 1
+	joypad1_status_lo:	.space 1
+						.space 1
+	joypad1_status_hi:	.space 1
+						.space 1
 
-	joypad2_status_lo:	.byte 1
-						.byte 1
-	joypad2_status_hi:	.byte 1
-						.byte 1
+	joypad2_status_lo:	.space 1
+						.space 1
+	joypad2_status_hi:	.space 1
+						.space 1
 
-	vsync_counter:		.word 1
+	vsync_counter:		.space 2
 	
 #if TRUE_RANDOM_GEN == 1
-	random_value:			.word 1
+	random_value:			.space 2
 #endif
 
 .section .text

--- a/kernel/videoMode1/videoMode1.s
+++ b/kernel/videoMode1/videoMode1.s
@@ -68,10 +68,10 @@
 
 .section .bss
 	vram: 	  		.space VRAM_SIZE	;allocate space for the video memory (VRAM)
-	font_table_lo:	.byte 1			;pointer to user font table
-	font_table_hi:	.byte 1	
-	tile_table_lo:	.byte 1
-	tile_table_hi:	.byte 1
+	font_table_lo:	.space 1			;pointer to user font table
+	font_table_hi:	.space 1
+	tile_table_lo:	.space 1
+	tile_table_hi:	.space 1
 	
 .section .text
 

--- a/kernel/videoMode10/videoMode10.s
+++ b/kernel/videoMode10/videoMode10.s
@@ -60,9 +60,9 @@
 
 .section .bss
 	vram: 	  	.space VRAM_SIZE	;allocate space for the video memory (VRAM)
-	tile_table_lo:	.byte 1
-	tile_table_hi:	.byte 1
-	font_tile_index:.byte 1
+	tile_table_lo:	.space 1
+	tile_table_hi:	.space 1
+	font_tile_index:.space 1
 
 .section .text
 

--- a/kernel/videoMode13/videoMode13core.s
+++ b/kernel/videoMode13/videoMode13core.s
@@ -104,20 +104,20 @@
 	ram_tiles_restore:  	.space RAM_TILES_COUNT*3 ;vram addr|Tile
 
 	sprites_tile_banks: 	.space 8
-	tile_table_lo:			.byte 1
-	tile_table_hi:			.byte 1
-	font_tile_index:		.byte 1 
+	tile_table_lo:			.space 1
+	tile_table_hi:			.space 1
+	font_tile_index:		.space 1
 
 
 	;ScreenType struct members
 	Screen:
-		overlay_height:			.byte 1
-		overlay_tile_bank:		.byte 1
+		overlay_height:			.space 1
+		overlay_tile_bank:		.space 1
 	#if SCROLLING == 1
-		screen_scrollX:			.byte 1
-		screen_scrollY:			.byte 1
-		screen_scrollHeight:	.byte 1
-		screen_tile_bank:		.byte 1
+		screen_scrollX:			.space 1
+		screen_scrollY:			.space 1
+		screen_scrollHeight:	.space 1
+		screen_tile_bank:		.space 1
 	#endif
 
 .section .text

--- a/kernel/videoMode2/videoMode2.s
+++ b/kernel/videoMode2/videoMode2.s
@@ -70,17 +70,17 @@
 
 	sprites:			.space 32*SPRITE_STRUCT_SIZE ;|X|Y|TILE INDEX|	
 	screenSections:		.space SCREEN_SECTION_STRUCT_SIZE*SCREEN_SECTIONS_COUNT
-	spritesOptions:		.byte 1		;b0 overflow: 0=clip, 1=flick
+	spritesOptions:		.space 1		;b0 overflow: 0=clip, 1=flick
 	
-	sprites_tiletable_lo: .byte 1
-	sprites_tiletable_hi: .byte 1
+	sprites_tiletable_lo: .space 1
+	sprites_tiletable_hi: .space 1
 
 	sprites_per_lines:	.space (SCREEN_TILES_V)*TILE_HEIGHT*MAX_SPRITES_PER_LINE ;|Y-offset(3bits)|Sprite No(5bits)|
 	sprite_buf_erase:	.space MAX_SPRITES_PER_LINE; ;4x8 bit pointers
-	rotate_spr_no:		.byte 1	
-	//tile_table_lo:	.byte 1
-	//tile_table_hi:	.byte 1
-	font_tile_index:.byte 1 
+	rotate_spr_no:		.space 1
+	//tile_table_lo:	.space 1
+	//tile_table_hi:	.space 1
+	font_tile_index:.space 1
 .section .text
 
 ;***************************************************

--- a/kernel/videoMode3/videoMode3core.s
+++ b/kernel/videoMode3/videoMode3core.s
@@ -106,19 +106,19 @@
 	ram_tiles_restore:  	.space RAM_TILES_COUNT*3 ;vram addr|Tile
 
 	sprites_tile_banks: 	.space 8
-	tile_table_lo:			.byte 1
-	tile_table_hi:			.byte 1
-	font_tile_index:		.byte 1 
+	tile_table_lo:			.space 1
+	tile_table_hi:			.space 1
+	font_tile_index:		.space 1
 
-	
+
 	;ScreenType struct members
 	Screen:
-		overlay_height:			.byte 1
-		overlay_tile_table:		.word 1
+		overlay_height:			.space 1
+		overlay_tile_table:		.space 2
 	#if SCROLLING == 1
-		screen_scrollX:			.byte 1
-		screen_scrollY:			.byte 1
-		screen_scrollHeight:	.byte 1
+		screen_scrollX:			.space 1
+		screen_scrollY:			.space 1
+		screen_scrollHeight:	.space 1
 	#endif
 
 .section .text

--- a/kernel/videoMode5/videoMode5.s
+++ b/kernel/videoMode5/videoMode5.s
@@ -57,10 +57,10 @@
 
 .section .bss
 	vram: 	  		.space VRAM_SIZE	;allocate space for the video memory (VRAM)
-	tile_table_lo:	.byte 1
-	tile_table_hi:	.byte 1
-	font_tile_index:.byte 1 
-	
+	tile_table_lo:	.space 1
+	tile_table_hi:	.space 1
+	font_tile_index:.space 1
+
 .section .text
 
 sub_video_mode5:

--- a/kernel/videoMode6/videoMode6.s
+++ b/kernel/videoMode6/videoMode6.s
@@ -45,7 +45,7 @@
 	shift_tbl_ram:	.space 8
 .align 1
 	vram: 	  		.space VRAM_SIZE 
-	ramTiles:		.space RAM_TILES_COUNT*TILE_HEIGHT ;8 pixels per spaces
+	ramTiles:		.space RAM_TILES_COUNT*TILE_HEIGHT ;8 pixels per bytes
 	nextFreeRamTile:.space 1
 	userRamTileIndex:.space 1
 	currentLine:	.space 1

--- a/kernel/videoMode6/videoMode6.s
+++ b/kernel/videoMode6/videoMode6.s
@@ -45,16 +45,16 @@
 	shift_tbl_ram:	.space 8
 .align 1
 	vram: 	  		.space VRAM_SIZE 
-	ramTiles:		.space RAM_TILES_COUNT*TILE_HEIGHT ;8 pixels per bytes
-	nextFreeRamTile:.byte 1
-	userRamTileIndex:.byte 1
-	currentLine:	.byte 1
-	fg_color:		.byte 1
-	bg_color:		.byte 1
-	tile_table_lo:			.byte 1
-	tile_table_hi:			.byte 1
-	font_tile_index:		.byte 1 
-	hsync_user_callback:  .word 1 ;pointer to function
+	ramTiles:		.space RAM_TILES_COUNT*TILE_HEIGHT ;8 pixels per spaces
+	nextFreeRamTile:.space 1
+	userRamTileIndex:.space 1
+	currentLine:	.space 1
+	fg_color:		.space 1
+	bg_color:		.space 1
+	tile_table_lo:			.space 1
+	tile_table_hi:			.space 1
+	font_tile_index:		.space 1
+	hsync_user_callback:  .space 2 ;pointer to function
 
 .section .text
 

--- a/kernel/videoMode7/videoMode7.s
+++ b/kernel/videoMode7/videoMode7.s
@@ -21,8 +21,8 @@
 	
 	vram: 	  		.space 1
 	line_buffer:	.space LINE_BUFFER_SIZE*2
-	render_start:	.byte 1
-	playback_start:	.byte 1
+	render_start:	.space 1
+	playback_start:	.space 1
 
 
 .section .text

--- a/kernel/videoMode9/videoMode9core.s
+++ b/kernel/videoMode9/videoMode9core.s
@@ -43,18 +43,18 @@
 
 .section .bss
 	vram: 	  		.space VRAM_SIZE	;allocate space for the video memory (VRAM)
-	tile_table_lo:	.byte 1
-	tile_table_hi:	.byte 1
-	font_tile_index:.byte 1
+	tile_table_lo:	.space 1
+	tile_table_hi:	.space 1
+	font_tile_index:.space 1
 	backgroundColor:.space VRAM_TILES_V
-	foregroundColor:.byte 1
-	cursor_x:		.byte 1
-	cursor_y:		.byte 1
-	cursor_visible:	.byte 1
-	cursor_tile:	.byte 1
-	cursor_speed:	.byte 1
-	cursor_current_delay: .byte 1
-	cursor_state:	.byte 1
+	foregroundColor:.space 1
+	cursor_x:		.space 1
+	cursor_y:		.space 1
+	cursor_visible:	.space 1
+	cursor_tile:	.space 1
+	cursor_speed:	.space 1
+	cursor_current_delay: .space 1
+	cursor_state:	.space 1
 
 
 .section .text


### PR DESCRIPTION
Newer gcc versions (6.2.0) don't like the way bytes are allocated in the bss and will refuse to compile.
See here: http://uzebox.org/forums/viewtopic.php?f=3&t=2371&p=18023#p18023

I replaced all .byte 1 occurrences in .bss by .space 1
.word 1 by .space 2
.long 1 by .space 4

All demos compile and I tested a mode 3 game with success. Another set of eyes to catch possible mistakes would be nice.