### PR TITLE
uzem: explicity define the c++ standard to support gcc 6

### DIFF
--- a/tools/uzem/Makefile
+++ b/tools/uzem/Makefile
@@ -85,7 +85,7 @@ endif
 ######################################
 # Global Flags
 ######################################
-CPPFLAGS += $(SDL_FLAGS) -D$(OS) -D_GNU_SOURCE=1 -DGUI=1 -DJOY_ANALOG_DEADZONE=8192
+CPPFLAGS += $(SDL_FLAGS) -D$(OS) -D_GNU_SOURCE=1 -DGUI=1 -DJOY_ANALOG_DEADZONE=8192 -std=gnu++98
 # TODO: fix warnings before enable 'CPPFLAGS += -Wall'
 
 ######################################


### PR DESCRIPTION
As discussed here: http://uzebox.org/forums/viewtopic.php?f=6&t=2411&p=18193#p18193

GCC 6 uses c++14 as default and uzem fails to compile as it's written in c++98