### PR TITLE
Fix 'ordered comparison between pointer and zero'

### DIFF
--- a/tools/uzem/SDEmulator.cpp
+++ b/tools/uzem/SDEmulator.cpp
@@ -150,7 +150,7 @@ void SDEmu::read(unsigned char *ptr) {
 	static int lastfile=-1;
 	static int lastfileStart=0;
 	static int lastfileEnd=0;
-	static FILE *fp=0;
+	static FILE *fp=NULL;
 	static int lastPos=0;
 
 	int pos;
@@ -200,7 +200,7 @@ void SDEmu::read(unsigned char *ptr) {
 				}
 			}
 		}
-		if (lastfile == -1 || fp <= (void*)0) { *ptr++ = 0; }
+		if (lastfile == -1 || fp == NULL) { *ptr++ = 0; }
 		else {
 			if(pos!=(lastPos+1)){
 				fseek(fp, pos - ((toc[lastfile].cluster_no-2)*clusterSize), SEEK_SET);

--- a/tools/uzem/SDEmulator.cpp
+++ b/tools/uzem/SDEmulator.cpp
@@ -200,7 +200,7 @@ void SDEmu::read(unsigned char *ptr) {
 				}
 			}
 		}
-		if (lastfile == -1 || fp <= 0) { *ptr++ = 0; }
+		if (lastfile == -1 || fp <= (void*)0) { *ptr++ = 0; }
 		else {
 			if(pos!=(lastPos+1)){
 				fseek(fp, pos - ((toc[lastfile].cluster_no-2)*clusterSize), SEEK_SET);


### PR DESCRIPTION
When compiling on Mac OSX "error: ordered comparison between pointer and zero" is encountered. This PR should be tested on Windows and Linux before merging.