### PR TITLE
Bugfix: videoMode3core.s, SetFont

### DIFF
--- a/kernel/videoMode3/videoMode3core.s
+++ b/kernel/videoMode3/videoMode3core.s
@@ -1532,7 +1532,7 @@ fill_vram_loop:
 .section .text.SetFont
 SetFont:
 	lds r21,font_tile_index
-	add r20,21
+	add r20,r21
 	rjmp SetTile	
 
 ;***********************************


### PR DESCRIPTION
Originally mentioned in: http://uzebox.org/forums/viewtopic.php?f=3&t=9994&p=29736&hilit=SetFont#p29736

In the line with add r20,21 (1535) the "r" is missing from "21". It should be "add r20,r21". It appears that 21 and r21 act the same though. Still, this is technically a typo and should be updated.