### PR TITLE
Add SetVsyncCounter function, fix compiler warning when SPRITES_AUTO_PROCESS=0

### DIFF
--- a/kernel/uzebox.h
+++ b/kernel/uzebox.h
@@ -82,6 +82,7 @@
 	extern   u8 GetVsyncFlag(void);
 	extern void ClearVsyncCounter();
 	extern u16	GetVsyncCounter();	
+        extern void SetVsyncCounter(u16 count);
 
 	extern void SetRenderingParameters(u8 firstScanlineToRender, u8 verticalTilesToRender);
 

--- a/kernel/uzeboxVideoEngineCore.s
+++ b/kernel/uzeboxVideoEngineCore.s
@@ -90,6 +90,7 @@
 .global IsRunningInEmulator
 .global GetVsyncCounter
 .global ClearVsyncCounter
+.global SetVsyncCounter
 
 ;Public variables
 .global sync_pulse
@@ -552,6 +553,18 @@ ClearVsyncCounter:
 	sts vsync_counter,r1
 	sts vsync_counter+1,r1
 	ret
+
+;************************************
+; Set the vsync counter.
+;
+; C-callable
+; r25:r24=(unsigned int)count
+;************************************
+.section .text.SetVsyncCounter
+SetVsyncCounter:
+        sts vsync_counter,r24
+        sts vsync_counter+1,r25
+        ret
 
 
 ;*****************************

--- a/kernel/videoMode3/videoMode3.c
+++ b/kernel/videoMode3/videoMode3.c
@@ -409,11 +409,11 @@ void DisplayLogo(){
 */
 void InitializeVideoMode(){
 
+	#if (SPRITES_AUTO_PROCESS != 0)
 	u8 i;
 
 	/* Disable sprites */
 
-	#if (SPRITES_AUTO_PROCESS != 0)
 	for(i = 0U; i < MAX_SPRITES; i++){
 		sprites[i].x = (SCREEN_TILES_H * TILE_WIDTH);
 		sprites[i].y = (SCREEN_TILES_V * TILE_HEIGHT);


### PR DESCRIPTION
Games relying on GetVsyncCounter() for world time should be able to save the value when the game is paused, and then restore it after the game is unpaused by calling SetVsyncCounter() to prevent world time from advancing while paused.

    Changes:
     - Add global SetVsyncCounter ASM function and C prototype
     - Fix compiler warning when SPRITES_AUTO_PROCESS=0
    
    Testing:
     - Tested against default ROMS, additional Mode 3 games.
