### PR TITLE
Peripheral Support(Uzem, Packrom, Whack a Mole, more)

### DIFF
--- a/demos/Whack-a-Mole/gameinfo.properties
+++ b/demos/Whack-a-Mole/gameinfo.properties
@@ -2,3 +2,4 @@ name=Whack-a-Mole
 author=Alec Bourque (Uze)
 year=2009
 genre=0
+mouse=default

--- a/tools/packrom/packrom.cpp
+++ b/tools/packrom/packrom.cpp
@@ -348,7 +348,7 @@ int main(int argc,char **argv)
 	}
 
 	memcpy(rom.header.marker,"UZEBOX",MARKER_SIZE);
-	memset(rom.header.reserved, 0, sizeof(rom.header.reserved));
+	//memset(rom.header.reserved, 0, sizeof(rom.header.reserved));
 	rom.header.version=HEADER_VERSION;
 	rom.header.target=0;
 	rom.header.crc32=chksum_crc32(rom.progmem+HEADER_SIZE, rom.header.progSize);

--- a/tools/packrom/packrom.cpp
+++ b/tools/packrom/packrom.cpp
@@ -25,6 +25,7 @@
  * Revisions:
  * ----------
  * 1.3: 4/9/2012 - Fixed parse_hex_nibble bug (s >= 'a' && s <= 'f')
+ * 1.4: 4/7/2023 - Added peripheral bit fields(devices supported, and emulator defaults)
  */
 
 #include <iostream>
@@ -36,10 +37,15 @@
 
 #define HEADER_VERSION 1
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 3
+#define VERSION_MINOR 4
 #define MAX_PROG_SIZE 61440 //65536-4096
 #define HEADER_SIZE 512
 #define MARKER_SIZE 6
+
+#define PERIPHERAL_MOUSE 1
+#define PERIPHERAL_KEYBOARD 2
+#define PERIPHERAL_MULTITAP 4
+#define PERIPHERAL_ESP8266 8
 
 #if defined (_MSC_VER) && _MSC_VER >= 1400
 // don't whine about sprintf and fopen.
@@ -67,9 +73,10 @@ typedef struct{
 	u8 author[32];
 	u8 icon[16*16];
 	u32 crc32;
-	u8 mouse;
+	u8 psupport; //peripherals supported
 	u8 description[64];
-    u8 reserved[114];
+	u8 pdefault; //peripherals to enable by default(Emulator)
+	u8 reserved[113];
 }RomHeader;
 
 union ROM{
@@ -93,7 +100,7 @@ u32 crc_tab[256];
  */
 u32 chksum_crc32 (unsigned char *block, unsigned int length)
 {
-   unsigned long crc;
+   register unsigned long crc;
    unsigned long i;
 
    crc = 0xFFFFFFFF;
@@ -288,6 +295,43 @@ int main(int argc,char **argv)
 			}else if(!strncmp(line,"year=",5)){
 				rom.header.year=(u16) strtoul(line+5,NULL,10);
 				fprintf(stderr,"\tYear: %i\n", rom.header.year);
+
+			}else if(!strncmp(line,"mouse=support",13)){
+				rom.header.psupport |= PERIPHERAL_MOUSE;
+				fprintf(stderr,"\tMouse: Enabled\n");
+
+			}else if(!strncmp(line,"keyboard=enabled",16)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tKeyboard: Enabled\n");
+
+			}else if(!strncmp(line,"multitap=enabled",16)){
+				rom.header.psupport |= PERIPHERAL_MULTITAP;
+				fprintf(stderr,"\tMultitap: Enabled\n");
+
+			}else if(!strncmp(line,"esp8266=enabled",15)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tESP8266: Enabled\n");
+
+			}else if(!strncmp(line,"mouse=default",13)){
+				rom.header.psupport |= PERIPHERAL_MOUSE;
+				rom.header.pdefault |= PERIPHERAL_MOUSE;
+				fprintf(stderr,"\tMouse: Default\n");
+
+			}else if(!strncmp(line,"keyboard=default",16)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				rom.header.pdefault |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tKeyboard: Default\n");
+
+			}else if(!strncmp(line,"multitap=default",16)){
+				rom.header.psupport |= PERIPHERAL_MULTITAP;
+				rom.header.pdefault |= PERIPHERAL_MULTITAP;
+				fprintf(stderr,"\tMultitap: Default\n");
+
+			}else if(!strncmp(line,"esp8266=default",15)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				rom.header.pdefault |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tESP8266: Default\n");
+
 			}
 		}
 		fclose (file);
@@ -323,12 +367,6 @@ int main(int argc,char **argv)
 
 
 	fclose(out_file);
-
-	//while (1)
-	//{
-	//	if ('n' == getchar())
-	//	   break;
-	//}
 
 	return 0;
 }

--- a/tools/packrom/packrom.cpp
+++ b/tools/packrom/packrom.cpp
@@ -77,7 +77,7 @@ typedef struct{
 	u8 description[64];
 	u8 pdefault; //peripherals to enable by default(Emulator)
 	u8 reserved[113];
-}RomHeader;
+}RomHeader; //if modified, uzerom.h must be updated
 
 union ROM{
 	u8 progmem[MAX_PROG_SIZE+HEADER_SIZE];
@@ -100,7 +100,7 @@ u32 crc_tab[256];
  */
 u32 chksum_crc32 (unsigned char *block, unsigned int length)
 {
-   register unsigned long crc;
+   unsigned long crc;
    unsigned long i;
 
    crc = 0xFFFFFFFF;
@@ -309,7 +309,7 @@ int main(int argc,char **argv)
 				fprintf(stderr,"\tMultitap: Enabled\n");
 
 			}else if(!strncmp(line,"esp8266=enabled",15)){
-				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				rom.header.psupport |= PERIPHERAL_ESP8266;
 				fprintf(stderr,"\tESP8266: Enabled\n");
 
 			}else if(!strncmp(line,"mouse=default",13)){
@@ -328,8 +328,8 @@ int main(int argc,char **argv)
 				fprintf(stderr,"\tMultitap: Default\n");
 
 			}else if(!strncmp(line,"esp8266=default",15)){
-				rom.header.psupport |= PERIPHERAL_KEYBOARD;
-				rom.header.pdefault |= PERIPHERAL_KEYBOARD;
+				rom.header.psupport |= PERIPHERAL_ESP8266;
+				rom.header.pdefault |= PERIPHERAL_ESP8266;
 				fprintf(stderr,"\tESP8266: Default\n");
 
 			}
@@ -348,6 +348,7 @@ int main(int argc,char **argv)
 	}
 
 	memcpy(rom.header.marker,"UZEBOX",MARKER_SIZE);
+	memset(rom.header.reserved, 0, sizeof(rom.header.reserved));
 	rom.header.version=HEADER_VERSION;
 	rom.header.target=0;
 	rom.header.crc32=chksum_crc32(rom.progmem+HEADER_SIZE, rom.header.progSize);

--- a/tools/uzem/uzem.cpp
+++ b/tools/uzem/uzem.cpp
@@ -254,7 +254,7 @@ int main(int argc,char **argv)
                     return 1;
                 }
                 // enable mouse support if required
-                if(uzeRomHeader.mouse){
+                if(uzeRomHeader.pdefault & PERIPHERAL_MOUSE){
                     uzebox.pad_mode = avr8::SNES_MOUSE;
                     printf("Mouse support enabled\n");
                 }

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -74,20 +74,20 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
             printf("Error: cannot parse version %d UzeROM files.\n",header->version);
         }
 
-        char psupport_str[256];
-        char pdefault_str[256];
+        char psupport_str[256] = {0};
+        char pdefault_str[256] = {0};
         //header->psupport = buf[338]; /* the peripherals the ROM supports */
-        if(header->psupport & PERIPHERAL_MOUSE){ sprintf(psupport_str+strlen(psupport_str), "Mouse,");}
-        if(header->psupport & PERIPHERAL_KEYBOARD){ sprintf(psupport_str+strlen(psupport_str), "Keyboard,"); }
-        if(header->psupport & PERIPHERAL_MULTITAP){ sprintf(psupport_str+strlen(psupport_str), "Multitap,"); }
-        if(header->psupport & PERIPHERAL_ESP8266){ sprintf(psupport_str+strlen(psupport_str), "ESP8266,"); }
+        if(header->psupport & PERIPHERAL_MOUSE){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Mouse,");}
+        if(header->psupport & PERIPHERAL_KEYBOARD){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Keyboard,"); }
+        if(header->psupport & PERIPHERAL_MULTITAP){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Multitap,"); }
+        if(header->psupport & PERIPHERAL_ESP8266){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "ESP8266,"); }
         if(strlen(psupport_str) && psupport_str[strlen(psupport_str)-1] == ','){ psupport_str[strlen(psupport_str)-1] == '\0'; } // remove trailing comma, if present
 
         //header->pdefault // the peripherals that should be "connected" at start(save the user some hotkey presses)
-        if(header->pdefault & PERIPHERAL_MOUSE){ sprintf(pdefault_str+strlen(pdefault_str), "Mouse,");}
-        if(header->pdefault & PERIPHERAL_KEYBOARD){ sprintf(pdefault_str+strlen(pdefault_str), "Keyboard,"); }
-        if(header->pdefault & PERIPHERAL_MULTITAP){ sprintf(pdefault_str+strlen(pdefault_str), "Multitap,"); }
-        if(header->pdefault & PERIPHERAL_ESP8266){ sprintf(pdefault_str+strlen(pdefault_str), "ESP8266,"); }
+        if(header->pdefault & PERIPHERAL_MOUSE){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Mouse,");}
+        if(header->pdefault & PERIPHERAL_KEYBOARD){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Keyboard,"); }
+        if(header->pdefault & PERIPHERAL_MULTITAP){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Multitap,"); }
+        if(header->pdefault & PERIPHERAL_ESP8266){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "ESP8266,"); }
         if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
 
 

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -77,17 +77,17 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
         char psupport_str[256];
         char pdefault_str[256];
         //header->psupport = buf[338]; /* the peripherals the ROM supports */
-        if(header->psupport & PERIPHERAL_MOUSE){ sprintf((char *)psupport_str+strlen(psupport_str), "Mouse,");}
-        if(header->psupport & PERIPHERAL_KEYBOARD){ sprintf((char *)psupport_str+strlen(psupport_str), "Keyboard,"); }
-        if(header->psupport & PERIPHERAL_MULTITAP){ sprintf((char *)psupport_str+strlen(psupport_str), "Multitap,"); }
-        if(header->psupport & PERIPHERAL_ESP8266){ sprintf((char *)psupport_str+strlen(psupport_str), "ESP8266,"); }
+        if(header->psupport & PERIPHERAL_MOUSE){ sprintf(psupport_str+strlen(psupport_str), "Mouse,");}
+        if(header->psupport & PERIPHERAL_KEYBOARD){ sprintf(psupport_str+strlen(psupport_str), "Keyboard,"); }
+        if(header->psupport & PERIPHERAL_MULTITAP){ sprintf(psupport_str+strlen(psupport_str), "Multitap,"); }
+        if(header->psupport & PERIPHERAL_ESP8266){ sprintf(psupport_str+strlen(psupport_str), "ESP8266,"); }
         if(strlen(psupport_str) && psupport_str[strlen(psupport_str)-1] == ','){ psupport_str[strlen(psupport_str)-1] == '\0'; } // remove trailing comma, if present
 
         //header->pdefault // the peripherals that should be "connected" at start(save the user some hotkey presses)
-        if(header->pdefault & PERIPHERAL_MOUSE){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Mouse,");}
-        if(header->pdefault & PERIPHERAL_KEYBOARD){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Keyboard,"); }
-        if(header->pdefault & PERIPHERAL_MULTITAP){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Multitap,"); }
-        if(header->pdefault & PERIPHERAL_ESP8266){ sprintf((char *)pdefault_str+strlen(pdefault_str), "ESP8266,"); }
+        if(header->pdefault & PERIPHERAL_MOUSE){ sprintf(pdefault_str+strlen(pdefault_str), "Mouse,");}
+        if(header->pdefault & PERIPHERAL_KEYBOARD){ sprintf(pdefault_str+strlen(pdefault_str), "Keyboard,"); }
+        if(header->pdefault & PERIPHERAL_MULTITAP){ sprintf(pdefault_str+strlen(pdefault_str), "Multitap,"); }
+        if(header->pdefault & PERIPHERAL_ESP8266){ sprintf(pdefault_str+strlen(pdefault_str), "ESP8266,"); }
         if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
 
 

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -73,10 +73,30 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
         if(header->version != HEADER_VERSION){
             printf("Error: cannot parse version %d UzeROM files.\n",header->version);
         }
-        printf("%s\n",header->name);
-        printf("%s\n",header->author);
-        printf("%d\n",header->year);
-        
+
+        char psupport_str[256];
+        char pdefault_str[256];
+        //header->psupport = buf[338]; /* the peripherals the ROM supports */
+        if(header->psupport & PERIPHERAL_MOUSE){ sprintf((char *)psupport_str+strlen(psupport_str), "Mouse,");}
+        if(header->psupport & PERIPHERAL_KEYBOARD){ sprintf((char *)psupport_str+strlen(psupport_str), "Keyboard,"); }
+        if(header->psupport & PERIPHERAL_MULTITAP){ sprintf((char *)psupport_str+strlen(psupport_str), "Multitap,"); }
+        if(header->psupport & PERIPHERAL_ESP8266){ sprintf((char *)psupport_str+strlen(psupport_str), "ESP8266,"); }
+        if(strlen(psupport_str) && psupport_str[strlen(psupport_str)-1] == ','){ psupport_str[strlen(psupport_str)-1] == '\0'; } // remove trailing comma, if present
+
+        //header->pdefault // the peripherals that should be "connected" at start(save the user some hotkey presses)
+        if(header->pdefault & PERIPHERAL_MOUSE){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Mouse,");}
+        if(header->pdefault & PERIPHERAL_KEYBOARD){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Keyboard,"); }
+        if(header->pdefault & PERIPHERAL_MULTITAP){ sprintf((char *)pdefault_str+strlen(pdefault_str), "Multitap,"); }
+        if(header->pdefault & PERIPHERAL_ESP8266){ sprintf((char *)pdefault_str+strlen(pdefault_str), "ESP8266,"); }
+        if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
+
+
+        printf("Name:\t%s\n",header->name);
+        printf("Author:\t%s\n",header->author);
+        printf("Year:\t%d\n",header->year);
+        printf("Support: %s\n",psupport_str);
+        printf("Default: %s\n",pdefault_str);
+
         if(header->target == 0){
             printf("Uzebox 1.0 - ATmega644\n");
         }

--- a/tools/uzem/uzerom.h
+++ b/tools/uzem/uzerom.h
@@ -30,12 +30,18 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <stdint.h>
 
 #ifndef UZEROM_H
+#define UZEROM_H
 
 #define HEADER_VERSION 1
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
 #define MAX_PROG_SIZE 61440 //65536-4096
 #define HEADER_SIZE 512
+
+#define PERIPHERAL_MOUSE 1
+#define PERIPHERAL_KEYBOARD 2
+#define PERIPHERAL_MULTITAP 4
+#define PERIPHERAL_ESP8266 8
 
 #pragma pack( 1 )
 struct RomHeader{
@@ -49,9 +55,10 @@ struct RomHeader{
     uint8_t author[32];
     uint8_t icon[16*16];
     uint32_t crc32;
-    uint8_t mouse;
-	uint8_t description[64];
-    uint8_t reserved[114];
+    uint8_t psupport; //supported peripherals
+    uint8_t description[64];
+    uint8_t pdefault; //default enabled peripherals(Emulator only)
+    uint8_t reserved[113];
 };
 #pragma pack()
 

--- a/tools/uzem/uzerom.h
+++ b/tools/uzem/uzerom.h
@@ -44,7 +44,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define PERIPHERAL_ESP8266 8
 
 #pragma pack( 1 )
-struct RomHeader{
+struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     //Header fields (512 bytes)
     uint8_t marker[6]; //'UZEBOX'
     uint8_t version; //header version


### PR DESCRIPTION
Packrom did not actually have support for UzeROM "mouse" variable. Turned this into a bitfield of "psupport" for peripherals supported by a ROM. Used 1 reserved byte for "pdefault", which is a device that should be default on in the emulator at start. Now can add something like this to gameinfo.properties:
mouse=support
keyboard=default
multitap=support
esp8266=default

Which lets the user know on ROM load all supported peripherals(which they can control via hotkey), and enables keyboard+esp8266 as on by default. This save presses of a hotkey(the user may not know) for games that clearly have an obvious optimum startup state in the emulator(Whack a Mole, Calculator, Solitaire, etc.).

Added support for these bitfields in Uzem. The same support has been added to CUzeBox in another branch.