### PR TITLE
Fix midiconv incorrect handling of program change events

### DIFF
--- a/tools/midiconv/src-programs/midiconv.cpp
+++ b/tools/midiconv/src-programs/midiconv.cpp
@@ -185,7 +185,7 @@ void convertSong(const string& infile, const string& outfile)
             setEventTick(mev, tempo);
             newmidi[track].append(*mev);
           }
-        } else if (((*mev)[0] & 0x90) && (*mev)[2] == 0x00) {
+        } else if (mev->isNoteOff()) {
           int chan = mev->getChannel();
           if ((options.getBoolean("no1") && chan == 0) ||
               (options.getBoolean("no2") && chan == 1) ||


### PR DESCRIPTION
Summary:
 - Incorrect logic was being used to test for a note off event, causing the else if statement that handled program change events after it to not fire. As a result, program change events beyond the first were not included in the output.

Changes:
 - Fix the logic that tests for note off events

Testing:
 - Compared the output against the previous version, and with a MIDI containing many program change events (thanks D3thAdd3r!).
 - Also compared it against the old Java MidiConvert program. Output is now nearly identical to the old Java version after running the result of midiconv through mconvert to compress it further for the streaming engine.