### PR TITLE
.uze peripheral support/defaults

### DIFF
--- a/demos/Whack-a-Mole/gameinfo.properties
+++ b/demos/Whack-a-Mole/gameinfo.properties
@@ -2,3 +2,4 @@ name=Whack-a-Mole
 author=Alec Bourque (Uze)
 year=2009
 genre=0
+mouse=default

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -73,10 +73,30 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
         if(header->version != HEADER_VERSION){
             printf("Error: cannot parse version %d UzeROM files.\n",header->version);
         }
-        printf("%s\n",header->name);
-        printf("%s\n",header->author);
-        printf("%d\n",header->year);
-        
+
+        char psupport_str[256] = {0};
+        char pdefault_str[256] = {0};
+        //header->psupport = buf[338]; /* the peripherals the ROM supports */
+        if(header->psupport & PERIPHERAL_MOUSE){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Mouse,");}
+        if(header->psupport & PERIPHERAL_KEYBOARD){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Keyboard,"); }
+        if(header->psupport & PERIPHERAL_MULTITAP){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Multitap,"); }
+        if(header->psupport & PERIPHERAL_ESP8266){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "ESP8266,"); }
+        if(strlen(psupport_str) && psupport_str[strlen(psupport_str)-1] == ','){ psupport_str[strlen(psupport_str)-1] == '\0'; } // remove trailing comma, if present
+
+        //header->pdefault // the peripherals that should be "connected" at start(save the user some hotkey presses)
+        if(header->pdefault & PERIPHERAL_MOUSE){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Mouse,");}
+        if(header->pdefault & PERIPHERAL_KEYBOARD){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Keyboard,"); }
+        if(header->pdefault & PERIPHERAL_MULTITAP){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "Multitap,"); }
+        if(header->pdefault & PERIPHERAL_ESP8266){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "ESP8266,"); }
+        if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
+
+
+        printf("Name:\t%s\n",header->name);
+        printf("Author:\t%s\n",header->author);
+        printf("Year:\t%d\n",header->year);
+        printf("Support: %s\n",psupport_str);
+        printf("Default: %s\n",pdefault_str);
+
         if(header->target == 0){
             printf("Uzebox 1.0 - ATmega644\n");
         }

--- a/tools/uzem/uzerom.h
+++ b/tools/uzem/uzerom.h
@@ -30,6 +30,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <stdint.h>
 
 #ifndef UZEROM_H
+#define UZEROM_H
 
 #define HEADER_VERSION 1
 #define VERSION_MAJOR 1
@@ -37,8 +38,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define MAX_PROG_SIZE 61440 //65536-4096
 #define HEADER_SIZE 512
 
+#define PERIPHERAL_MOUSE 1
+#define PERIPHERAL_KEYBOARD 2
+#define PERIPHERAL_MULTITAP 4
+#define PERIPHERAL_ESP8266 8
+
 #pragma pack( 1 )
-struct RomHeader{
+struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     //Header fields (512 bytes)
     uint8_t marker[6]; //'UZEBOX'
     uint8_t version; //header version
@@ -49,9 +55,10 @@ struct RomHeader{
     uint8_t author[32];
     uint8_t icon[16*16];
     uint32_t crc32;
-    uint8_t mouse;
-	uint8_t description[64];
-    uint8_t reserved[114];
+    uint8_t psupport; //supported peripherals
+    uint8_t description[64];
+    uint8_t pdefault; //default enabled peripherals(Emulator only)
+    uint8_t reserved[113];
 };
 #pragma pack()
 


### PR DESCRIPTION
Eliminated the .uze format "mouse" variable, as it was unused anywhere.

Used this, plus 1 more reserved byte for a peripheral support/default bit matrix. Added support for this more expandable format to Packrom and Uzem.

This is very important for peripheral adoption/support, because it minimizes the complexity of using peripherals in emulation. In addition it easily support more peripherals.

Essentially, for each peripheral, on a per game basis, the device can be "supported" which means the program optionally will work it it(but leave off by default), and "default" which means if this peripheral is an option, it is clearly preferred to use it(ie Whack a Mole game). This is used by the emulator, to present the user with an ideal emulation state from the start, instead of having to lookup hotkey behaviors. This could also be used by the bootloader or other programs, to display "supported" data to the user.

Example of where default is important for emulation(while allowing peripherals that may not be commonly used, but do work):
Any Uzenet game(turn on ESP8266 emulation by default)
UzeboxPC(turn on Keyboard emulation and host passthrough by default, it's required for use)
WhackAMole(turn on mouse emulation by default, it's required for use)
Solitaire(mouse is supported, but off by default for joypad cursor)
Calculator(*source lost, hex edit?* would turn on mouse emulation by default, it's required for use)
MegaBomber(esp8266=default, keyboard=supported)