### PR TITLE
JAMMA Additions

### DIFF
--- a/tools/packrom/packrom.cpp
+++ b/tools/packrom/packrom.cpp
@@ -47,6 +47,9 @@
 #define PERIPHERAL_MULTITAP 4
 #define PERIPHERAL_ESP8266 8
 
+#define JAMMA_VERTICAL 1
+#define JAMMA_HORIZONTAL 2
+
 #if defined (_MSC_VER) && _MSC_VER >= 1400
 // don't whine about sprintf and fopen.
 // could switch to sprintf_s but that's not standard.
@@ -67,17 +70,18 @@ typedef struct{
 	u8 marker[MARKER_SIZE];	//'UZEBOX'
 	u8 version;		//header version
 	u8 target;		//AVR target (ATmega644=0, ATmega1284=1)
-	u32 progSize;	//program memory size in bytes
+	u32 progSize;		//program memory size in bytes
 	u16 year;
 	u8 name[32];
 	u8 author[32];
 	u8 icon[16*16];
 	u32 crc32;
-	u8 psupport; //peripherals supported
+	u8 psupport;		//peripherals supported
 	u8 description[64];
-	u8 pdefault; //peripherals to enable by default(Emulator)
-	u8 reserved[113];
-}RomHeader; //if modified, uzerom.h must be updated
+	u8 pdefault;		//peripherals to enable by default(Emulator)
+	u8 jamma;		//JAMMA options
+	u8 reserved[112];
+}RomHeader;
 
 union ROM{
 	u8 progmem[MAX_PROG_SIZE+HEADER_SIZE];
@@ -100,7 +104,7 @@ u32 crc_tab[256];
  */
 u32 chksum_crc32 (unsigned char *block, unsigned int length)
 {
-   unsigned long crc;
+   register unsigned long crc;
    unsigned long i;
 
    crc = 0xFFFFFFFF;
@@ -298,19 +302,19 @@ int main(int argc,char **argv)
 
 			}else if(!strncmp(line,"mouse=support",13)){
 				rom.header.psupport |= PERIPHERAL_MOUSE;
-				fprintf(stderr,"\tMouse: Enabled\n");
+				fprintf(stderr,"\tMouse: Supported\n");
 
-			}else if(!strncmp(line,"keyboard=enabled",16)){
+			}else if(!strncmp(line,"keyboard=support",16)){
 				rom.header.psupport |= PERIPHERAL_KEYBOARD;
-				fprintf(stderr,"\tKeyboard: Enabled\n");
+				fprintf(stderr,"\tKeyboard: Supported\n");
 
-			}else if(!strncmp(line,"multitap=enabled",16)){
+			}else if(!strncmp(line,"multitap=support",16)){
 				rom.header.psupport |= PERIPHERAL_MULTITAP;
-				fprintf(stderr,"\tMultitap: Enabled\n");
+				fprintf(stderr,"\tMultitap: Supported\n");
 
-			}else if(!strncmp(line,"esp8266=enabled",15)){
-				rom.header.psupport |= PERIPHERAL_ESP8266;
-				fprintf(stderr,"\tESP8266: Enabled\n");
+			}else if(!strncmp(line,"esp8266=support",15)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tESP8266: Supported\n");
 
 			}else if(!strncmp(line,"mouse=default",13)){
 				rom.header.psupport |= PERIPHERAL_MOUSE;
@@ -331,6 +335,14 @@ int main(int argc,char **argv)
 				rom.header.psupport |= PERIPHERAL_ESP8266;
 				rom.header.pdefault |= PERIPHERAL_ESP8266;
 				fprintf(stderr,"\tESP8266: Default\n");
+
+			}else if(!strncmp(line,"JAMMA=vertical",14)){
+				rom.header.jamma |= JAMMA_VERTICAL;
+				fprintf(stderr,"\tJAMMA: Vertical\n");
+
+			}else if(!strncmp(line,"JAMMA=horizontal",16)){
+				rom.header.jamma |= JAMMA_HORIZONTAL;
+				fprintf(stderr,"\tJAMMA: Horizontal\n");
 
 			}
 		}

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -384,7 +384,10 @@ void avr8::write_io_x(u8 addr,u8 value)
 
 					SDL_UpdateTexture(texture, NULL, surface->pixels, surface->pitch);
 					SDL_RenderClear(renderer);
-					SDL_RenderCopy(renderer, texture, NULL, NULL);
+					if(vertical) //probably only useful for JAMMA
+						SDL_RenderCopyEx(renderer, texture, NULL, NULL, 90, NULL, SDL_FLIP_NONE);
+					else
+						SDL_RenderCopy(renderer, texture, NULL, NULL);
 					SDL_RenderPresent(renderer);
 
 #ifndef __EMSCRIPTEN__
@@ -2016,7 +2019,10 @@ bool avr8::init_gui()
 	atexit(SDL_Quit);
 	init_joysticks();
 
-	window = SDL_CreateWindow(caption,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,630,448,fullscreen?SDL_WINDOW_FULLSCREEN:SDL_WINDOW_RESIZABLE);
+	int monitorWidth = vertical ? 630:630;
+	int monitorHeight = vertical ? 630:448;
+ 
+	window = SDL_CreateWindow(caption,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,monitorWidth,monitorHeight,fullscreen?SDL_WINDOW_FULLSCREEN:SDL_WINDOW_RESIZABLE);
 	if (!window){
 		fprintf(stderr, "CreateWindow failed: %s\n", SDL_GetError());
 		return false;
@@ -2028,7 +2034,7 @@ bool avr8::init_gui()
 		return false;
 	}
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
-	SDL_RenderSetLogicalSize(renderer, 630, 448);
+	SDL_RenderSetLogicalSize(renderer, monitorWidth, monitorHeight);
 
 	surface = SDL_CreateRGBSurface(0, VIDEO_DISP_WIDTH, 224, 32, 0, 0, 0, 0);
 	if(!surface){
@@ -2999,7 +3005,7 @@ void avr8::LoadEEPROMFile(const char* filename){
 
 void avr8::shutdown(int errcode){
 #if defined(__WIN32__)
-    if(hDisk != INVALID_HANDLE_VALUE){
+    if(hDisk != teINVALID_HANDLE_VALUE){
         CloseHandle (hDisk);        
         VirtualFree (lpSector, 0, MEM_RELEASE);
     }        

--- a/tools/uzem/avr8.h
+++ b/tools/uzem/avr8.h
@@ -466,6 +466,8 @@ public:
 	u8  scanline_buf[2048]; // For collecting pixels from a single scanline
 	u8  pixel_raw;          // Raw (8 bit) input pixel
 	bool fullscreen;
+	bool jamma;
+	bool vertical;
 
 	/*Audio*/
 	ringBuffer audioRing;

--- a/tools/uzem/gdbserver.cpp
+++ b/tools/uzem/gdbserver.cpp
@@ -1388,3 +1388,4 @@ void GdbServer::SendPosition(int signo) {
 
     gdb_send_reply(reply);
 }
+

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -76,6 +76,7 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
 
         char psupport_str[256] = {0};
         char pdefault_str[256] = {0};
+        char jamma_str[256] = {0};
         //header->psupport = buf[338]; /* the peripherals the ROM supports */
         if(header->psupport & PERIPHERAL_MOUSE){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Mouse,");}
         if(header->psupport & PERIPHERAL_KEYBOARD){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Keyboard,"); }
@@ -90,12 +91,23 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
         if(header->pdefault & PERIPHERAL_ESP8266){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "ESP8266,"); }
         if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
 
+        if(header->jamma & JAMMA_VERTICAL){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Vertical,"); }
+        if(header->jamma & JAMMA_HORIZONTAL){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Horizontal,"); }
+        if(strlen(jamma_str) && jamma_str[strlen(jamma_str)-1] == ','){ jamma_str[strlen(jamma_str)-1] == '\0'; } // remove trailing comma, if present
 
         printf("Name:\t%s\n",header->name);
         printf("Author:\t%s\n",header->author);
         printf("Year:\t%d\n",header->year);
-        printf("Support: %s\n",psupport_str);
-        printf("Default: %s\n",pdefault_str);
+
+        if(psupport_str[0] || pdefault_str[0]){
+            printf("Peripherals:\n");
+            printf("\tSupport: %s\n",psupport_str);
+            printf("\tDefault: %s\n",pdefault_str);
+        }
+
+        if(jamma_str[0] != '\0'){
+            printf("JAMMA: %s\n",jamma_str);
+        }
 
         if(header->target == 0){
             printf("Uzebox 1.0 - ATmega644\n");
@@ -200,3 +212,4 @@ bool loadHex(const char *in_filename,unsigned char *buffer,unsigned int *bytesRe
 
 	return true;
 }
+

--- a/tools/uzem/uzerom.h
+++ b/tools/uzem/uzerom.h
@@ -43,6 +43,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define PERIPHERAL_MULTITAP 4
 #define PERIPHERAL_ESP8266 8
 
+#define JAMMA_VERTICAL 1
+#define JAMMA_HORIZONTAL 2
+
 #pragma pack( 1 )
 struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     //Header fields (512 bytes)
@@ -58,7 +61,8 @@ struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     uint8_t psupport; //supported peripherals
     uint8_t description[64];
     uint8_t pdefault; //default enabled peripherals(Emulator only)
-    uint8_t reserved[113];
+    uint8_t jamma; //JAMMA options
+    uint8_t reserved[112];
 };
 #pragma pack()
 


### PR DESCRIPTION
Added JAMMA option support to the .uze file format. Used 1 of the remaining 113 reserved bytes for up to 8 JAMMA options. Currently games can specify one of these in their gameinfo.properties:
JAMMA=vertical
or
JAMMA=horizontal

Added Vertical orientation support to Uzem either via command line option, or auto-detected based on .uze JAMMA bits. Not tested on web emulator, but I believe this will work there or any platform SDL is operating correctly.