### PR TITLE
JAMMA Additions

### DIFF
--- a/tools/packrom/packrom.cpp
+++ b/tools/packrom/packrom.cpp
@@ -47,6 +47,15 @@
 #define PERIPHERAL_MULTITAP 4
 #define PERIPHERAL_ESP8266 8
 
+#define JAMMA_ROTATE_90 1
+#define JAMMA_ROTATE_180 2
+#define JAMMA_ROTATE_270 4
+#define JAMMA_FLIP_H 8
+#define JAMMA_FLIP_V 16
+#define JAMMA_B0 32 //future use...
+#define JAMMA_B1 64
+#define JAMMA_B2 128
+
 #if defined (_MSC_VER) && _MSC_VER >= 1400
 // don't whine about sprintf and fopen.
 // could switch to sprintf_s but that's not standard.
@@ -67,17 +76,18 @@ typedef struct{
 	u8 marker[MARKER_SIZE];	//'UZEBOX'
 	u8 version;		//header version
 	u8 target;		//AVR target (ATmega644=0, ATmega1284=1)
-	u32 progSize;	//program memory size in bytes
+	u32 progSize;		//program memory size in bytes
 	u16 year;
 	u8 name[32];
 	u8 author[32];
 	u8 icon[16*16];
 	u32 crc32;
-	u8 psupport; //peripherals supported
+	u8 psupport;		//peripherals supported
 	u8 description[64];
-	u8 pdefault; //peripherals to enable by default(Emulator)
-	u8 reserved[113];
-}RomHeader; //if modified, uzerom.h must be updated
+	u8 pdefault;		//peripherals to enable by default(Emulator)
+	u8 jamma;		//JAMMA options
+	u8 reserved[112];
+}RomHeader;
 
 union ROM{
 	u8 progmem[MAX_PROG_SIZE+HEADER_SIZE];
@@ -298,19 +308,19 @@ int main(int argc,char **argv)
 
 			}else if(!strncmp(line,"mouse=support",13)){
 				rom.header.psupport |= PERIPHERAL_MOUSE;
-				fprintf(stderr,"\tMouse: Enabled\n");
+				fprintf(stderr,"\tMouse: Supported\n");
 
-			}else if(!strncmp(line,"keyboard=enabled",16)){
+			}else if(!strncmp(line,"keyboard=support",16)){
 				rom.header.psupport |= PERIPHERAL_KEYBOARD;
-				fprintf(stderr,"\tKeyboard: Enabled\n");
+				fprintf(stderr,"\tKeyboard: Supported\n");
 
-			}else if(!strncmp(line,"multitap=enabled",16)){
+			}else if(!strncmp(line,"multitap=support",16)){
 				rom.header.psupport |= PERIPHERAL_MULTITAP;
-				fprintf(stderr,"\tMultitap: Enabled\n");
+				fprintf(stderr,"\tMultitap: Supported\n");
 
-			}else if(!strncmp(line,"esp8266=enabled",15)){
-				rom.header.psupport |= PERIPHERAL_ESP8266;
-				fprintf(stderr,"\tESP8266: Enabled\n");
+			}else if(!strncmp(line,"esp8266=support",15)){
+				rom.header.psupport |= PERIPHERAL_KEYBOARD;
+				fprintf(stderr,"\tESP8266: Supported\n");
 
 			}else if(!strncmp(line,"mouse=default",13)){
 				rom.header.psupport |= PERIPHERAL_MOUSE;
@@ -331,6 +341,26 @@ int main(int argc,char **argv)
 				rom.header.psupport |= PERIPHERAL_ESP8266;
 				rom.header.pdefault |= PERIPHERAL_ESP8266;
 				fprintf(stderr,"\tESP8266: Default\n");
+
+			}else if(!strncmp(line,"JAMMA=rotate90",14)){
+				rom.header.jamma |= JAMMA_ROTATE_90;
+				fprintf(stderr,"\tJAMMA: Rotate 90\n");
+
+			}else if(!strncmp(line,"JAMMA=rotate180",15)){
+				rom.header.jamma |= JAMMA_ROTATE_180;
+				fprintf(stderr,"\tJAMMA: Rotate 180\n");
+
+			}else if(!strncmp(line,"JAMMA=rotate270",15)){
+				rom.header.jamma |= JAMMA_ROTATE_270;
+				fprintf(stderr,"\tJAMMA: Rotate 270\n");
+
+			}else if(!strncmp(line,"JAMMA=flipH",11)){
+				rom.header.jamma |= JAMMA_FLIP_H;
+				fprintf(stderr,"\tJAMMA: Flip Horizontal\n");
+
+			}else if(!strncmp(line,"JAMMA=flipV",11)){
+				rom.header.jamma |= JAMMA_FLIP_H;
+				fprintf(stderr,"\tJAMMA: Flip Vertical\n");
 
 			}
 		}

--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -384,7 +384,10 @@ void avr8::write_io_x(u8 addr,u8 value)
 
 					SDL_UpdateTexture(texture, NULL, surface->pixels, surface->pitch);
 					SDL_RenderClear(renderer);
-					SDL_RenderCopy(renderer, texture, NULL, NULL);
+					if(orientation != -1 || mirror) //probably only useful for JAMMA
+						SDL_RenderCopyEx(renderer, texture, NULL, NULL, orientation, NULL, mirror);
+					else
+						SDL_RenderCopy(renderer, texture, NULL, NULL);
 					SDL_RenderPresent(renderer);
 
 #ifndef __EMSCRIPTEN__
@@ -2016,7 +2019,13 @@ bool avr8::init_gui()
 	atexit(SDL_Quit);
 	init_joysticks();
 
-	window = SDL_CreateWindow(caption,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,630,448,fullscreen?SDL_WINDOW_FULLSCREEN:SDL_WINDOW_RESIZABLE);
+	int monitorWidth = 630;
+	int monitorHeight = 448;
+	if(orientation == 90 || orientation == 270){
+	    monitorHeight = 630;
+	}
+ 
+	window = SDL_CreateWindow(caption,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,monitorWidth,monitorHeight,fullscreen?SDL_WINDOW_FULLSCREEN:SDL_WINDOW_RESIZABLE);
 	if (!window){
 		fprintf(stderr, "CreateWindow failed: %s\n", SDL_GetError());
 		return false;
@@ -2028,7 +2037,7 @@ bool avr8::init_gui()
 		return false;
 	}
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
-	SDL_RenderSetLogicalSize(renderer, 630, 448);
+	SDL_RenderSetLogicalSize(renderer, monitorWidth, monitorHeight);
 
 	surface = SDL_CreateRGBSurface(0, VIDEO_DISP_WIDTH, 224, 32, 0, 0, 0, 0);
 	if(!surface){

--- a/tools/uzem/avr8.h
+++ b/tools/uzem/avr8.h
@@ -466,6 +466,9 @@ public:
 	u8  scanline_buf[2048]; // For collecting pixels from a single scanline
 	u8  pixel_raw;          // Raw (8 bit) input pixel
 	bool fullscreen;
+	bool jamma;
+	int orientation; //default: -1(no rotation), 90, 180, 270, mostly for JAMMA(.uze JAMMA settings can be overriden with flag)
+	SDL_RendererFlip mirror; //default: SDL_FLIP_NONE, 1: SDL_FLIP_HORIZONTAL, 2: SDL_FLIP_VERTICAL, 3: Both
 
 	/*Audio*/
 	ringBuffer audioRing;
@@ -642,22 +645,22 @@ public:
 	void draw_memorymap();
 	void trigger_interrupt(unsigned int location);
 	unsigned int exec();
-    void spi_calculateClock();    
+	void spi_calculateClock();    
 	void update_hardware();
 	void update_hardware_fast();
 	void update_hardware_ins();
-    void update_spi();
-    void SDLoadImage(char *filename);    
-    void SDBuildMBR(SDPartitionEntry* entry);    
-    void SDMapDrive(const char* driveLetter); //only for WIN32
-    void SDSeekToOffset(u32 offset);    
-    u8 SDReadByte();    
-    void SDWriteByte(u8 value);    
-    void SDCommit();
-    void LoadEEPROMFile(const char* filename);
-    void shutdown(int errcode);
-    void idle(void);
-    void uzekb_handle_key(SDL_Event &ev);
+	void update_spi();
+	void SDLoadImage(char *filename);    
+	void SDBuildMBR(SDPartitionEntry* entry);    
+	void SDMapDrive(const char* driveLetter); //only for WIN32
+	void SDSeekToOffset(u32 offset);    
+	u8 SDReadByte();    
+	void SDWriteByte(u8 value);    
+	void SDCommit();
+	void LoadEEPROMFile(const char* filename);
+	void shutdown(int errcode);
+	void idle(void);
+	void uzekb_handle_key(SDL_Event &ev);
 
 };
 #endif

--- a/tools/uzem/uzerom.cpp
+++ b/tools/uzem/uzerom.cpp
@@ -76,6 +76,7 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
 
         char psupport_str[256] = {0};
         char pdefault_str[256] = {0};
+        char jamma_str[256] = {0};
         //header->psupport = buf[338]; /* the peripherals the ROM supports */
         if(header->psupport & PERIPHERAL_MOUSE){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Mouse,");}
         if(header->psupport & PERIPHERAL_KEYBOARD){ snprintf(psupport_str+strlen(psupport_str), sizeof(psupport_str)-strlen(psupport_str), "Keyboard,"); }
@@ -90,12 +91,26 @@ bool loadUzeImage(char* in_filename,RomHeader *header,u8 *buffer){
         if(header->pdefault & PERIPHERAL_ESP8266){ snprintf(pdefault_str+strlen(pdefault_str), sizeof(pdefault_str)-strlen(pdefault_str), "ESP8266,"); }
         if(strlen(pdefault_str) && pdefault_str[strlen(pdefault_str)-1] == ','){ pdefault_str[strlen(pdefault_str)-1] == '\0'; } // remove trailing comma, if present
 
+        if(header->jamma & JAMMA_ROTATE_90){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Rotate 90,"); }
+        if(header->jamma & JAMMA_ROTATE_180){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Rotate 180,"); }
+        if(header->jamma & JAMMA_ROTATE_270){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Rotate 270,"); }
+        if(header->jamma & JAMMA_FLIP_H){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Mirror Horizontal,"); }
+        if(header->jamma & JAMMA_FLIP_V){ snprintf(jamma_str+strlen(jamma_str), sizeof(jamma_str)-strlen(jamma_str), "Mirror Vertical,"); }
+        if(strlen(jamma_str) && jamma_str[strlen(jamma_str)-1] == ','){ jamma_str[strlen(jamma_str)-1] == '\0'; } // remove trailing comma, if present
 
         printf("Name:\t%s\n",header->name);
         printf("Author:\t%s\n",header->author);
         printf("Year:\t%d\n",header->year);
-        printf("Support: %s\n",psupport_str);
-        printf("Default: %s\n",pdefault_str);
+
+        if(psupport_str[0] || pdefault_str[0]){
+            printf("Peripherals:\n");
+            printf("\tSupport: %s\n",psupport_str);
+            printf("\tDefault: %s\n",pdefault_str);
+        }
+
+        if(jamma_str[0] != '\0'){
+            printf("JAMMA: %s\n",jamma_str);
+        }
 
         if(header->target == 0){
             printf("Uzebox 1.0 - ATmega644\n");
@@ -200,3 +215,4 @@ bool loadHex(const char *in_filename,unsigned char *buffer,unsigned int *bytesRe
 
 	return true;
 }
+

--- a/tools/uzem/uzerom.h
+++ b/tools/uzem/uzerom.h
@@ -43,6 +43,15 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define PERIPHERAL_MULTITAP 4
 #define PERIPHERAL_ESP8266 8
 
+#define JAMMA_ROTATE_90 1
+#define JAMMA_ROTATE_180 2
+#define JAMMA_ROTATE_270 4
+#define JAMMA_FLIP_H 8
+#define JAMMA_FLIP_V 16
+#define JAMMA_B0 32 //future use...
+#define JAMMA_B1 64
+#define JAMMA_B2 128
+
 #pragma pack( 1 )
 struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     //Header fields (512 bytes)
@@ -58,7 +67,8 @@ struct RomHeader{//if this is modified, packrom.cpp needs to be updated
     uint8_t psupport; //supported peripherals
     uint8_t description[64];
     uint8_t pdefault; //default enabled peripherals(Emulator only)
-    uint8_t reserved[113];
+    uint8_t jamma; //JAMMA options
+    uint8_t reserved[112];
 };
 #pragma pack()
 


### PR DESCRIPTION
Made packrom and Uzem additions to support arbitrary rotation/mirroring to match various possible arcade cabinet layouts. This allows the .uze file to automatically specify a particular rotation to use. This is expected to make JAMMA ROMs which aren't feasible to play in emulation currently, work transparently to the user(this behavior can be overridden with flags).

Method used should be basically no speed loss, and should work in any environment? Tested Linux Windowed of any size and full screen. Plan to extend these same options to CUzebox once discussed/modified/approved.