### PR TITLE
Add support for building Uzebox repo under Haiku

### DIFF
--- a/demos/BcDash/default/Makefile
+++ b/demos/BcDash/default/Makefile
@@ -70,7 +70,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
+all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
 
 ## Compile Kernel files
 uzeboxVideoEngineCore.o: $(KERNEL_DIR)/uzeboxVideoEngineCore.s
@@ -111,10 +111,6 @@ $(TARGET): $(OBJECTS)
 %.uze: $(TARGET)
 	@echo
 	-$(UZEBIN_DIR)packrom $(GAME).hex $(GAME).uze $(INFO)
-
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/DonkeyKong/default/Makefile
+++ b/demos/DonkeyKong/default/Makefile
@@ -61,7 +61,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: ../data/tiles0.inc ../data/tiles1.inc ../data/sprites.inc $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
+all: ../data/tiles0.inc ../data/tiles1.inc ../data/sprites.inc $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
 
 ## Regenerate the graphics include file
 ../data/tiles0.inc: ../data/tiles0.png ../data/tiles0.xml
@@ -108,9 +108,6 @@ $(TARGET): $(OBJECTS)
 	@echo
 	-$(UZEBIN_DIR)packrom $(GAME).hex $(GAME).uze $(INFO)
 
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Frogger/default/Makefile
+++ b/demos/Frogger/default/Makefile
@@ -53,7 +53,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: ../data/tiles.inc ../data/sprites.inc $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
+all: ../data/tiles.inc ../data/sprites.inc $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
 
 ## Regenerate the graphics include file
 ../data/tiles.inc: ../data/tiles.png ../data/tiles.xml
@@ -97,10 +97,6 @@ $(TARGET): $(OBJECTS)
 %.uze: $(TARGET)
 	@echo
 	-$(UZEBIN_DIR)packrom $(GAME).hex $(GAME).uze $(INFO)
-
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/PacMan/default/Makefile
+++ b/demos/PacMan/default/Makefile
@@ -58,7 +58,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
+all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
 
 ## Compile Kernel files
 uzeboxVideoEngineCore.o: $(KERNEL_DIR)/uzeboxVideoEngineCore.s
@@ -96,10 +96,6 @@ $(TARGET): $(OBJECTS)
 %.uze: $(TARGET)
 	@echo
 	-$(UZEBIN_DIR)packrom $(GAME).hex $(GAME).uze $(INFO)
-
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SPIRamMusicDemo/default/Makefile
+++ b/demos/SPIRamMusicDemo/default/Makefile
@@ -56,8 +56,8 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-##all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
-all: SD_MUSIC.DAT ../data/sdMusicConfig.cfg ../data/sdPCMConfig.cfg $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss size
+##all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
+all: SD_MUSIC.DAT ../data/sdMusicConfig.cfg ../data/sdPCMConfig.cfg $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss
 
 ## Regenerate the music resources
 SD_MUSIC.DAT: ../data/sdMusicConfig.cfg ../data/sdPCMConfig.cfg
@@ -110,10 +110,6 @@ AVRSIZEFLAGS := -A ${TARGET}
 ##ifneq (,$(findstring MINGW,$(UNAME)))
 ##AVRSIZEFLAGS := -C --mcu=${MCU} ${TARGET}
 ##endif
-
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SpaceInvaders/default/Makefile
+++ b/demos/SpaceInvaders/default/Makefile
@@ -53,7 +53,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze size
+all: $(TARGET) $(GAME).hex $(GAME).eep $(GAME).lss $(GAME).uze
 
 ## Compile Kernel files
 uzeboxVideoEngineCore.o: $(KERNEL_DIR)/uzeboxVideoEngineCore.s
@@ -91,10 +91,6 @@ $(TARGET): $(OBJECTS)
 %.uze: $(TARGET)
 	@echo
 	-$(UZEBIN_DIR)packrom $(GAME).hex $(GAME).uze $(INFO)
-
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Zombienator/default/Makefile
+++ b/demos/Zombienator/default/Makefile
@@ -51,7 +51,7 @@ LINKONLYOBJECTS =
 INCLUDES = -I"$(KERNEL_DIR)" 
 
 ## Build
-all: $(TARGET) $(PROJECT).hex $(PROJECT).eep $(PROJECT).lss $(GAME).uze size
+all: $(TARGET) $(PROJECT).hex $(PROJECT).eep $(PROJECT).lss $(GAME).uze
 
 
 ## Compile
@@ -110,10 +110,6 @@ AVRSIZEFLAGS := -A ${TARGET}
 ifneq (,$(findstring MINGW,$(UNAME)))
 AVRSIZEFLAGS := -C --mcu=${MCU} ${TARGET}
 endif
-	
-size: ${TARGET}
-	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/tools/gconvert/Makefile
+++ b/tools/gconvert/Makefile
@@ -97,6 +97,16 @@ RM := -rm -rf
 MTOOLS = utils/mtools
 endif
 
+## Haiku #############################
+ifeq ($(UNAME),Haiku)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
+endif
+
 ifeq ($(PLATFORM),Unknown)
         $(error Unsupported platform!)
 endif

--- a/tools/packrom/Makefile
+++ b/tools/packrom/Makefile
@@ -97,6 +97,16 @@ RM := -rm -rf
 MTOOLS = utils/mtools
 endif
 
+## Haiku #############################
+ifeq ($(UNAME),Haiku)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
+endif
+
 ifeq ($(PLATFORM),Unknown)
         $(error Unsupported platform!)
 endif


### PR DESCRIPTION
This PR enables the Uzebox repo to build under the Haiku OS.

I had to make minor patches to the packrom and gconvert makefiles and I had to remove the `size:` build target from a few demos Makefiles because it triggers an error about `avr-size` using a invalid option `-C` when trying to build the repo under Haiku.

All of the demos seem to build and run fine without the size: target, what is that size target used for, if anything? Am I not OK just to rip the `size:` target out?