### PR TITLE
Add support for building repo with FreeBSD and Haiku

### DIFF
--- a/demos/BcDash/default/Makefile
+++ b/demos/BcDash/default/Makefile
@@ -114,7 +114,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/BcDash/default/Makefile
+++ b/demos/BcDash/default/Makefile
@@ -114,7 +114,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/DonkeyKong/default/Makefile
+++ b/demos/DonkeyKong/default/Makefile
@@ -65,11 +65,11 @@ all: ../data/tiles0.inc ../data/tiles1.inc ../data/sprites.inc $(TARGET) $(GAME)
 
 ## Regenerate the graphics include file
 ../data/tiles0.inc: ../data/tiles0.png ../data/tiles0.xml
-	gconvert ../data/tiles0.xml
+	$(UZEBIN_DIR)gconvert ../data/tiles0.xml
 ../data/tiles1.inc: ../data/tiles1.png ../data/tiles1.xml
-	gconvert ../data/tiles1.xml
+	$(UZEBIN_DIR)gconvert ../data/tiles1.xml
 ../data/sprites.inc: ../data/sprites.png ../data/sprites.xml
-	gconvert ../data/sprites.xml
+	$(UZEBIN_DIR)gconvert ../data/sprites.xml
 
 ## Compile Kernel files
 uzeboxVideoEngineCore.o: $(KERNEL_DIR)/uzeboxVideoEngineCore.s
@@ -110,7 +110,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/DonkeyKong/default/Makefile
+++ b/demos/DonkeyKong/default/Makefile
@@ -110,7 +110,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Frogger/default/Makefile
+++ b/demos/Frogger/default/Makefile
@@ -57,9 +57,9 @@ all: ../data/tiles.inc ../data/sprites.inc $(TARGET) $(GAME).hex $(GAME).eep $(G
 
 ## Regenerate the graphics include file
 ../data/tiles.inc: ../data/tiles.png ../data/tiles.xml
-	gconvert ../data/tiles.xml
+	$(UZEBIN_DIR)gconvert ../data/tiles.xml
 ../data/sprites.inc: ../data/sprites.png ../data/sprites.xml
-	gconvert ../data/sprites.xml
+	$(UZEBIN_DIR)gconvert ../data/sprites.xml
 
 ## Compile Kernel files
 uzeboxVideoEngineCore.o: $(KERNEL_DIR)/uzeboxVideoEngineCore.s
@@ -100,7 +100,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Frogger/default/Makefile
+++ b/demos/Frogger/default/Makefile
@@ -100,7 +100,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/PacMan/default/Makefile
+++ b/demos/PacMan/default/Makefile
@@ -99,7 +99,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/PacMan/default/Makefile
+++ b/demos/PacMan/default/Makefile
@@ -99,7 +99,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SPIRamMusicDemo/default/Makefile
+++ b/demos/SPIRamMusicDemo/default/Makefile
@@ -113,7 +113,7 @@ AVRSIZEFLAGS := -A ${TARGET}
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SPIRamMusicDemo/default/Makefile
+++ b/demos/SPIRamMusicDemo/default/Makefile
@@ -113,7 +113,7 @@ AVRSIZEFLAGS := -A ${TARGET}
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SpaceInvaders/default/Makefile
+++ b/demos/SpaceInvaders/default/Makefile
@@ -94,7 +94,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/SpaceInvaders/default/Makefile
+++ b/demos/SpaceInvaders/default/Makefile
@@ -94,7 +94,7 @@ $(TARGET): $(OBJECTS)
 
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Zombienator/default/Makefile
+++ b/demos/Zombienator/default/Makefile
@@ -113,7 +113,7 @@ endif
 	
 size: ${TARGET}
 	@echo
-	@avr-size -A ${TARGET}
+	@-avr-size -C --mcu=${MCU} ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/demos/Zombienator/default/Makefile
+++ b/demos/Zombienator/default/Makefile
@@ -113,7 +113,7 @@ endif
 	
 size: ${TARGET}
 	@echo
-	@avr-size -C --mcu=${MCU} ${TARGET}
+	@avr-size -A ${TARGET}
 
 ## Clean target
 .PHONY: clean

--- a/tools/gconvert/Makefile
+++ b/tools/gconvert/Makefile
@@ -75,7 +75,7 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## FreeBSD  #############################
+## FreeBSD ############################
 ifeq ($(UNAME),FreeBSD)
 OS := LINUX
 PLATFORM := Unix
@@ -83,6 +83,16 @@ CC := g++
 MKDIR := mkdir -p
 RM := rm -rf
 MTOOLS = 
+endif
+
+## Haiku ##############################
+ifeq ($(UNAME),Haiku)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
 endif
 
 ## Mac OS #############################

--- a/tools/gconvert/Makefile
+++ b/tools/gconvert/Makefile
@@ -75,6 +75,16 @@ RM := rm -rf
 MTOOLS = 
 endif
 
+## FreeBSD  #############################
+ifeq ($(UNAME),FreeBSD)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS = 
+endif
+
 ## Mac OS #############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX

--- a/tools/packrom/Makefile
+++ b/tools/packrom/Makefile
@@ -75,8 +75,7 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-
-## FreeBSD  #############################
+## FreeBSD ############################
 ifeq ($(UNAME),FreeBSD)
 OS := LINUX
 PLATFORM := Unix
@@ -84,6 +83,16 @@ CC := g++
 MKDIR := mkdir -p
 RM := rm -rf
 MTOOLS = 
+endif
+
+## Haiku ##############################
+ifeq ($(UNAME),Haiku)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
 endif
 
 ## Mac OS #############################

--- a/tools/packrom/Makefile
+++ b/tools/packrom/Makefile
@@ -75,6 +75,17 @@ RM := rm -rf
 MTOOLS = 
 endif
 
+
+## FreeBSD  #############################
+ifeq ($(UNAME),FreeBSD)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS = 
+endif
+
 ## Mac OS #############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX

--- a/tools/uzem/Makefile
+++ b/tools/uzem/Makefile
@@ -146,6 +146,23 @@ RM := rm -rf
 MTOOLS = 
 endif
 
+## FreeBSD #############################
+ifeq ($(UNAME),FreeBSD)
+OS := LINUX
+PLATFORM := Unix
+ifeq ($(EMSCRIPTEN_BUILD),1)
+    SDL_FLAGS :=
+    CC := emcc
+else
+    SDL_FLAGS := $(shell sdl2-config --cflags)
+    LDFLAGS += $(shell sdl2-config --libs)
+    CC := g++
+endif
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS = 
+endif
+
 ## Mac OS #############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX


### PR DESCRIPTION
I tweaked some makefiles and now the Uzebox repo buillds under FreeBSD (tested under v14) and Haiku (tested under beta4).

To build the repo:

FreeBSD / GhostBSD

pkg install gmake gcc sdl2 os-generic-userland-devtools avr-gcc avr-libc
<clone repo, cd uzebox>
gmake

Haiku

pkgman install avr_gcc avr_libc libsdl2_devel
<clone repo, cd uzebox>
make

EDIT 27th June 2024

This PR now also includes pcm2hex for converting audio files for use in Uzebox programs.