### PR TITLE
fix FadeIn() and FadeOut() in Mode 5

### DIFF
--- a/kernel/videoMode5/videoMode5.c
+++ b/kernel/videoMode5/videoMode5.c
@@ -74,5 +74,5 @@
 
 	//Callback invoked during hsync
 	void VideoModeVsync(){		
-		//ProcessFading();
+		ProcessFading();
 	}


### PR DESCRIPTION
The call to ProcessFading() was commented out.  Because of this all calls to FadeIn()/FadeOut() with a speed > 0 in Mode 5 resulted in a complete hang.

Looking at the source code, Mode 10 should have the same problem, but as I've only found this bug and verified this fix under Mode 5, I did not include a fix for Mode 10.

I've already posted this on the Uzebox forums – this is by no means a "work faster to fix this" reminder ;-)
I need this fix in a repository so that I can refer to it in the build instructions of Uzepede. After creating my fork of the Uzebox repo and comitting this fix, opening the Pull Request was just a click away, so here we are.