### PR TITLE
Add NetBSD support

### DIFF
--- a/tools/gconvert/Makefile
+++ b/tools/gconvert/Makefile
@@ -75,7 +75,7 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## FreeBSD ############################
+## FreeBSD ###########################
 ifeq ($(UNAME),FreeBSD)
 OS := LINUX
 PLATFORM := Unix
@@ -85,7 +85,17 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## Haiku ##############################
+## NetBSD ############################
+ifeq ($(UNAME),NetBSD)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
+endif
+
+## Haiku #############################
 ifeq ($(UNAME),Haiku)
 OS := LINUX
 PLATFORM := Unix
@@ -95,7 +105,7 @@ RM := rm -rf
 MTOOLS =
 endif
 
-## Mac OS #############################
+## Mac OS ############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX
 PLATFORM := Unix

--- a/tools/packrom/Makefile
+++ b/tools/packrom/Makefile
@@ -75,7 +75,7 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## FreeBSD ############################
+## FreeBSD ###########################
 ifeq ($(UNAME),FreeBSD)
 OS := LINUX
 PLATFORM := Unix
@@ -85,7 +85,17 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## Haiku ##############################
+## NetBSD ############################
+ifeq ($(UNAME),NetBSD)
+OS := LINUX
+PLATFORM := Unix
+CC := g++
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
+endif
+
+## Haiku #############################
 ifeq ($(UNAME),Haiku)
 OS := LINUX
 PLATFORM := Unix
@@ -95,7 +105,7 @@ RM := rm -rf
 MTOOLS =
 endif
 
-## Mac OS #############################
+## Mac OS ############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX
 PLATFORM := Unix

--- a/tools/uzem/Makefile
+++ b/tools/uzem/Makefile
@@ -146,7 +146,7 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## FreeBSD #############################
+## FreeBSD ###########################
 ifeq ($(UNAME),FreeBSD)
 OS := LINUX
 PLATFORM := Unix
@@ -163,7 +163,24 @@ RM := rm -rf
 MTOOLS = 
 endif
 
-## Mac OS #############################
+## NetBSD ############################
+ifeq ($(UNAME),NetBSD)
+OS := LINUX
+PLATFORM := Unix
+ifeq ($(EMSCRIPTEN_BUILD),1)
+    SDL_FLAGS :=
+    CC := emcc
+else
+    SDL_FLAGS := $(shell sdl2-config --cflags) -I/usr/pkg/include
+    LDFLAGS += $(shell sdl2-config --libs)
+    CC := g++
+endif
+MKDIR := mkdir -p
+RM := rm -rf
+MTOOLS =
+endif
+
+## Mac OS ############################
 ifeq ($(UNAME),Darwin)
 OS := MACOSX
 PLATFORM := Unix


### PR DESCRIPTION
There are several vintage computer platforms where NetBSD is often your only choice if you want to run a modern OS so I have made the few small changes that were required to get the Uzebox repo to build successfully under NetBSD 10.0.

The following NetBSD command can be used to install all of the required build dependencies

`pkgin install git gcc14 avr-gcc avr-libc gmake SDL2`

After installing those and cloning the Uzebox repo, the user only has to run `gmake` to build the repo.