### PR TITLE
New init function for the SPI RAM library to allow for detecting SPI RAM size

### DIFF
--- a/demos/sdspiram/sdspiram.c
+++ b/demos/sdspiram/sdspiram.c
@@ -49,6 +49,7 @@ int main(){
 	u8  buf[8];
 	u8  rby;
 	u8  pos;
+	u8  spiRamSize;
 
 	/* Prepare screen */
 
@@ -63,7 +64,8 @@ int main(){
 	** sdCardInitNoBuffer() routine will have a hefty 15 sec timeout. */
 
 	sdCardInitNoBuffer();
-	if (!SpiRamInit()){
+	spiRamSize = SpiRamInitGetSize();
+	if (spiRamSize == 0U){
 		Print( (SCREEN_TILES_H / 2U) - 5U,
 		       (SCREEN_TILES_V / 2U) - 1U,
 		       PSTR("No SPI RAM!") );
@@ -133,6 +135,12 @@ int main(){
 	for(pos = 0U; pos < SCREEN_TILES_V; pos++){
 		PrintChar(0U, pos, '0' + (pos % 10U));
 	}
+
+	/* Print detected SPI RAM size */
+	PrintByte(4U, 8U, spiRamSize, false);
+	Print( 5U,
+	       8U,
+	       PSTR("x64K of SPI RAM available") );
 
 	/* Prints a string on the screen. Note that PSTR() is a macro that
 	** tells the compiler to store the string in flash. 14 is half the

--- a/kernel/spiram.h
+++ b/kernel/spiram.h
@@ -42,6 +42,13 @@
 */
 u8 SpiRamInit(void);
 
+/*
+** Initializes SPI RAM and determines its size. It is necessary to call it
+** even after an SD Card init to set up the SPI RAM's Chip Select. Returns SPI
+** RAM chip size in 64K units on success, 0 on failure.
+*/
+u8 SpiRamInitGetSize(void);
+
 
 
 /*


### PR DESCRIPTION
Detection supports the following chip sizes: 128K, 256K, 512K, 1M, 2M, 4M and 8M. The library was intended for chips having 3 address bytes, hence the smallest size supported is 128Kbytes.