### PR TITLE
bin2hex: Fix compilation with GCC 15

### DIFF
--- a/tools/bin2hex/Makefile
+++ b/tools/bin2hex/Makefile
@@ -7,7 +7,7 @@ bin2hex: bin2hex.o
 	$(CC) -o $(BIN_DIR)/bin2hex bin2hex.o
 
 bin2hex.o : bin2hex.c
-	$(CC) -c bin2hex.c
+	$(CC) -std=gnu99 -c bin2hex.c
 
 clean :
 	rm -f $(BIN_DIR)/bin2hex bin2hex.o


### PR DESCRIPTION
GCC 15 defaults to C23 which introduces some errors with the existing code. Just fall back to C99 for now.