### PR TITLE
Update Uzebox BOM to replace SNES connector seller

### DIFF
--- a/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
+++ b/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
@@ -1,4 +1,4 @@
-Uzebox BOM Rev. F5 - Part footprints compatible with Uzebox PCB Rev 1.3.3 (Feb. 2026)
+Uzebox BOM Rev. F5 - Part footprints compatible with Uzebox PCB Rev 1.3.3 (April 2026)
 
 Parts sourced from Digikey
 
@@ -56,7 +56,7 @@ Parts sourced from Digikey
 
 1   AD725ARZ-ND                 IC ENCODER RGB TO NTSC 16-SOIC      (U2) See alternative source below(*)
 
-1   497-1443-5-ND               IC REG LINEAR 5V 1.5A TO220         (IC2)
+1   MC7805ACTGOS-ND             IC REG LINEAR 5V 1A TO220           (IC2)
 
 1   641-1310-1-ND               1N4001 DIODE RECTIFIER 1A 50V DO-41 (D1)
 

--- a/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
+++ b/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
@@ -1,4 +1,4 @@
-Uzebox BOM Rev. F5 - Part footprints compatible with Uzebox PCB Rev 1.3.3 (Nov. 2025)
+Uzebox BOM Rev. F5 - Part footprints compatible with Uzebox PCB Rev 1.3.3 (Feb. 2026)
 
 Parts sourced from Digikey
 
@@ -56,7 +56,7 @@ Parts sourced from Digikey
 
 1   AD725ARZ-ND                 IC ENCODER RGB TO NTSC 16-SOIC      (U2) See alternative source below(*)
 
-1   MC7805ACTGOS-ND             IC REG POS 1A 5V                    (IC2)
+1   497-1443-5-ND               IC REG LINEAR 5V 1.5A TO220         (IC2)
 
 1   641-1310-1-ND               1N4001 DIODE RECTIFIER 1A 50V DO-41 (D1)
 

--- a/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
+++ b/schematics/Uzebox/V5.0/Uzebox-V5.0-BOM.txt
@@ -98,7 +98,7 @@ Parts sourced elsewhere
 
 1   AD725ARZ (*)            IC ENCODER RGB TO NTSC 16-SOIC (alternate, much cheaper source) (U2)    https://vi.aliexpress.com/item/33022801012.html
 
-2   SNES Connectors         (Straight pin version) AliExpress.com   (SNESP1,SNESP2)                 Prefered model: https://vi.aliexpress.com/item/32828261927.html, Alternative model: https://vi.aliexpress.com/item/32838396935.html
+2   SNES Connectors         (Straight pin version) AliExpress.com   (SNESP1,SNESP2)                 Prefered model: https://www.aliexpress.com/item/32879502446.html, Alternative model: https://vi.aliexpress.com/item/32838396935.html
 
 1   PCB Rev 1.3.3           JLCPCB.com PCB Manufacturing service                                    See the following on how to order: https://uzebox.org/forums/viewtopic.php?p=33217#p33217
 


### PR DESCRIPTION
Update the BOMS RA SNES connector seller link.